### PR TITLE
Improve off-heap memory utilization

### DIFF
--- a/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/contention/benchmark/Parameters.java
+++ b/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/contention/benchmark/Parameters.java
@@ -20,7 +20,7 @@ public class Parameters {
 		keySize = 4,
         valSize = 4;
     
-    static boolean detailedStats = true;
+    public static boolean detailedStats = false;
 	static boolean change = false;
 
     static String benchClassName = "skiplists.lockfree.NonBlockingFriendlySkipListMap";

--- a/core/src/main/java/com/oath/oak/NativeAllocator/Block.java
+++ b/core/src/main/java/com/oath/oak/NativeAllocator/Block.java
@@ -32,6 +32,7 @@ class Block {
     ByteBuffer allocate(int size) {
         int now = allocated.getAndAdd(size);
         if (now + size > this.capacity) {
+             allocated.getAndAdd(-size);
             throw new OakOutOfMemoryException();
         }
         // the duplicate is needed for thread safeness, otherwise (in single threaded environment)


### PR DESCRIPTION
- Order free buffer list by size
- Limit the size on reused buffers to be no more than twice the requested size
  - If only large buffers are available, stop scanning and allocate a new buffer
- Added allocator statistics (not collected by default)
- Update allocated bytes counter not to reflect incorrect number when capacity is exceeded
- Updated benchmark to print recycled memory stats when detailed statistics are requested
    - Fixed detailed stats parameter default to be false
- Update/clean benchmark running script