### PR TITLE
Bug fixes

### DIFF
--- a/benchmarks/jmh/src/main/java/com/oath/oak/StringComparator.java
+++ b/benchmarks/jmh/src/main/java/com/oath/oak/StringComparator.java
@@ -42,14 +42,14 @@ class StringComparator implements OakComparator<String>{
     }
 
     @Override
-    public int compareSerializedKeyAndKey(ByteBuffer serializedKey, String key) {
-        int size1 = serializedKey.getInt(serializedKey.position());
-        int size2 = key.length();
+    public int compareKeyAndSerializedKey(String key, ByteBuffer serializedKey) {
+        int size1 = key.length();
+        int size2 = serializedKey.getInt(serializedKey.position());
 
         int it=0;
         while (it < size1 && it < size2) {
-            char c1 = serializedKey.getChar(Integer.BYTES + serializedKey.position() + it*Character.BYTES);
-            char c2 = key.charAt(it);
+            char c1 = key.charAt(it);
+            char c2 = serializedKey.getChar(Integer.BYTES + serializedKey.position() + it * Character.BYTES);
             int compare = Character.compare(c1, c2);
             if (compare != 0) {
                 return compare;

--- a/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/maps/MyBufferOak.java
+++ b/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/maps/MyBufferOak.java
@@ -64,11 +64,11 @@ class MyBufferOak {
         }
 
         @Override
-        public int compareSerializedKeyAndKey(ByteBuffer serializedKey, MyBuffer key) {
-            int pos1 = serializedKey.position();
-            int cap1 = serializedKey.getInt(pos1);
-            int pos2 = key.buffer.position();
-            int cap2 = key.buffer.capacity();
+        public int compareKeyAndSerializedKey(MyBuffer key, ByteBuffer serializedKey) {
+            int pos1 = key.buffer.position();
+            int cap1 = key.buffer.capacity();
+            int pos2 = serializedKey.position();
+            int cap2 = serializedKey.getInt(pos1);
             return compare(serializedKey, pos1 + Integer.BYTES, cap1, key.buffer, pos2, cap2);
 
         }

--- a/core/src/main/java/com/oath/oak/Chunk.java
+++ b/core/src/main/java/com/oath/oak/Chunk.java
@@ -560,7 +560,8 @@ public class Chunk<K, V> {
                 return pointToValue(opData);
             }
         }
-        // this is a put, try again (restart put)
+        // This is a put, in which case operation should restart,
+        // or PIACIP compute happened, which should return false
         return false;
     }
 

--- a/core/src/main/java/com/oath/oak/IntegerOakMap.java
+++ b/core/src/main/java/com/oath/oak/IntegerOakMap.java
@@ -1,0 +1,56 @@
+package com.oath.oak;
+
+import java.nio.ByteBuffer;
+
+public class IntegerOakMap {
+
+    public static OakComparator<Integer> comparator = new OakComparator<Integer>() {
+
+        @Override
+        public int compareKeys(Integer key1, Integer key2) {
+            return intsCompare(key1, key2);
+        }
+
+        @Override
+        public int compareSerializedKeys(ByteBuffer serializedKey1, ByteBuffer serializedKey2) {
+            int int1 = serializedKey1.getInt(serializedKey1.position());
+            int int2 = serializedKey2.getInt(serializedKey2.position());
+            return intsCompare(int1, int2);
+        }
+
+        @Override
+        public int compareSerializedKeyAndKey(ByteBuffer serializedKey, Integer key) {
+            int int1 = serializedKey.getInt(serializedKey.position());
+            return intsCompare(int1, key);
+        }
+    };
+
+    public static OakSerializer<Integer> serializer = new OakSerializer<Integer>() {
+
+        @Override
+        public void serialize(Integer obj, ByteBuffer targetBuffer) {
+            targetBuffer.putInt(targetBuffer.position(), obj);
+        }
+
+        @Override
+        public Integer deserialize(ByteBuffer serializedObj) {
+            return serializedObj.getInt(serializedObj.position());
+        }
+
+        @Override
+        public int calculateSize(Integer key) { return Integer.BYTES; }
+
+    };
+
+    public static OakMapBuilder<Integer, Integer> getDefaultBuilder() {
+        return new OakMapBuilder<Integer, Integer>()
+                .setKeySerializer(serializer)
+                .setValueSerializer(serializer)
+                .setMinKey(Integer.MIN_VALUE)
+                .setComparator(comparator);
+    }
+
+    private static int intsCompare(int int1, int int2) {
+        return Integer.compare(int1, int2);
+    }
+}

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -357,6 +357,8 @@ class InternalOakMap<K, V> {
             if (prevEi != ei) {
                 ei = prevEi;
                 prevHi = c.getHandleIndex(prevEi);
+                // We can swap the handle pointer *only* when previous handle was deleted (or prevHi == -1),
+                // otherwise operation should restart
                 if (prevHi != -1) {
                     return put(key, value, transformer);
                 }
@@ -465,6 +467,7 @@ class InternalOakMap<K, V> {
         }
 
         if (!finishAfterPublishing(opData, c)) {
+            c.freeHandle(hi);
             return putIfAbsent(key, value, transformer);
         }
 

--- a/core/src/main/java/com/oath/oak/OakComparator.java
+++ b/core/src/main/java/com/oath/oak/OakComparator.java
@@ -22,5 +22,5 @@ public interface OakComparator<K> extends Comparator<K> {
 
     int compareSerializedKeys(ByteBuffer serializedKey1, ByteBuffer serializedKey2);
 
-    int compareSerializedKeyAndKey(ByteBuffer serializedKey, K key);
+    int compareKeyAndSerializedKey(K key, ByteBuffer serializedKey);
 }

--- a/core/src/main/java/com/oath/oak/OakComparator.java
+++ b/core/src/main/java/com/oath/oak/OakComparator.java
@@ -8,15 +8,19 @@ package com.oath.oak;
 
 
 import java.nio.ByteBuffer;
+import java.util.Comparator;
 
 // IMPORTANT:
 // (1) input ByteBuffer position might be any non-negative integer
 // (2) input ByteBuffer position shouldn't be changed as a side effect of comparision
-public interface OakComparator<K> {
+public interface OakComparator<K> extends Comparator<K> {
+    default int compare(K key1, K key2) {
+        return compareKeys(key1, key2);
+    }
 
-  int compareKeys(K key1, K key2);
+    int compareKeys(K key1, K key2);
 
-  int compareSerializedKeys(ByteBuffer serializedKey1, ByteBuffer serializedKey2);
+    int compareSerializedKeys(ByteBuffer serializedKey1, ByteBuffer serializedKey2);
 
-  int compareSerializedKeyAndKey(ByteBuffer serializedKey, K key);
+    int compareSerializedKeyAndKey(ByteBuffer serializedKey, K key);
 }

--- a/core/src/main/java/com/oath/oak/OakMapBuilder.java
+++ b/core/src/main/java/com/oath/oak/OakMapBuilder.java
@@ -27,10 +27,10 @@ public class OakMapBuilder<K, V> {
     // comparators
     private OakComparator<K> comparator;
 
-  // Off-heap fields
-  private int chunkMaxItems;
-  private long memoryCapacity;
-  private OakMemoryAllocator memoryAllocator;
+    // Off-heap fields
+    private int chunkMaxItems;
+    private long memoryCapacity;
+    private OakMemoryAllocator memoryAllocator;
 
     public OakMapBuilder() {
         this.keySerializer = null;
@@ -60,10 +60,10 @@ public class OakMapBuilder<K, V> {
         return this;
     }
 
-  public OakMapBuilder<K, V> setChunkMaxItems(int chunkMaxItems) {
-    this.chunkMaxItems = chunkMaxItems;
-    return this;
-  }
+    public OakMapBuilder<K, V> setChunkMaxItems(int chunkMaxItems) {
+        this.chunkMaxItems = chunkMaxItems;
+        return this;
+    }
 
     public OakMapBuilder<K, V> setMemoryCapacity(long memoryCapacity) {
         this.memoryCapacity = memoryCapacity;

--- a/core/src/main/java/com/oath/oak/OakMapBuilder.java
+++ b/core/src/main/java/com/oath/oak/OakMapBuilder.java
@@ -8,8 +8,6 @@ package com.oath.oak;
 
 import com.oath.oak.NativeAllocator.OakNativeMemoryAllocator;
 
-import java.nio.ByteBuffer;
-
 /**
  * This class builds a new OakMap instance, and sets serializers, deserializers and allocation size calculators,
  * received from the user.
@@ -17,153 +15,85 @@ import java.nio.ByteBuffer;
  * @param <K> The key object type.
  * @param <V> The value object type.
  */
-public class OakMapBuilder<K,V> {
+public class OakMapBuilder<K, V> {
 
-  private final long MAX_MEM_CAPACITY = ((long)Integer.MAX_VALUE)*8; // 16GB per Oak by default
+    private final long MAX_MEM_CAPACITY = ((long) Integer.MAX_VALUE) * 8; // 16GB per Oak by default
 
-  private OakSerializer<K> keySerializer;
-  private OakSerializer<V> valueSerializer;
+    private OakSerializer<K> keySerializer;
+    private OakSerializer<V> valueSerializer;
 
-  private K minKey;
+    private K minKey;
 
-  // comparators
-  private OakComparator<K> comparator;
+    // comparators
+    private OakComparator<K> comparator;
 
   // Off-heap fields
   private int chunkMaxItems;
   private long memoryCapacity;
   private OakMemoryAllocator memoryAllocator;
 
-  public OakMapBuilder() {
-    this.keySerializer = null;
-    this.valueSerializer = null;
+    public OakMapBuilder() {
+        this.keySerializer = null;
+        this.valueSerializer = null;
 
-    this.minKey = null;
+        this.minKey = null;
 
-    this.comparator = null;
+        this.comparator = null;
 
-    this.chunkMaxItems = Chunk.MAX_ITEMS_DEFAULT;
-    this.memoryCapacity = MAX_MEM_CAPACITY;
-    this.memoryAllocator = null;
-  }
+        this.chunkMaxItems = Chunk.MAX_ITEMS_DEFAULT;
+        this.memoryCapacity = MAX_MEM_CAPACITY;
+        this.memoryAllocator = null;
+    }
 
-  public OakMapBuilder<K, V> setKeySerializer(OakSerializer<K> keySerializer) {
-    this.keySerializer = keySerializer;
-    return this;
-  }
+    public OakMapBuilder<K, V> setKeySerializer(OakSerializer<K> keySerializer) {
+        this.keySerializer = keySerializer;
+        return this;
+    }
 
-  public OakMapBuilder<K, V> setValueSerializer(OakSerializer<V> valueSerializer) {
-    this.valueSerializer = valueSerializer;
-    return this;
-  }
+    public OakMapBuilder<K, V> setValueSerializer(OakSerializer<V> valueSerializer) {
+        this.valueSerializer = valueSerializer;
+        return this;
+    }
 
-  public OakMapBuilder<K, V> setMinKey(K minKey) {
-    this.minKey = minKey;
-    return this;
-  }
+    public OakMapBuilder<K, V> setMinKey(K minKey) {
+        this.minKey = minKey;
+        return this;
+    }
 
   public OakMapBuilder<K, V> setChunkMaxItems(int chunkMaxItems) {
     this.chunkMaxItems = chunkMaxItems;
     return this;
   }
 
-  public OakMapBuilder<K, V> setMemoryCapacity(long memoryCapacity) {
-    this.memoryCapacity = memoryCapacity;
-    return this;
-  }
-
-  public OakMapBuilder<K, V> setComparator(OakComparator<K> comparator) {
-    this.comparator = comparator;
-    return this;
-  }
-
-  public OakMapBuilder<K, V> setMemoryAllocator(OakMemoryAllocator ma) {
-    this.memoryAllocator = ma;
-    return this;
-  }
-
-  public OakMap<K, V> build() {
-    ThreadIndexCalculator threadIndexCalculator = ThreadIndexCalculator.newInstance();
-
-    if (memoryAllocator == null) {
-      this.memoryAllocator = new OakNativeMemoryAllocator(memoryCapacity);
+    public OakMapBuilder<K, V> setMemoryCapacity(long memoryCapacity) {
+        this.memoryCapacity = memoryCapacity;
+        return this;
     }
 
-    MemoryManager memoryManager = new MemoryManager(memoryAllocator);
+    public OakMapBuilder<K, V> setComparator(OakComparator<K> comparator) {
+        this.comparator = comparator;
+        return this;
+    }
 
-    return new OakMap<>(
-            minKey,
-            keySerializer,
-            valueSerializer,
-            comparator, chunkMaxItems,
-            memoryManager, threadIndexCalculator);
-  }
+    public OakMapBuilder<K, V> setMemoryAllocator(OakMemoryAllocator ma) {
+        this.memoryAllocator = ma;
+        return this;
+    }
 
-  private static int intsCompare(int int1, int int2) {
-    return Integer.compare(int1, int2);
-  }
+    public OakMap<K, V> build() {
 
-  public static OakMapBuilder<Integer, Integer> getDefaultBuilder() {
+        if (memoryAllocator == null) {
+            this.memoryAllocator = new OakNativeMemoryAllocator(memoryCapacity);
+        }
 
-    OakSerializer<Integer> serializerK = new OakSerializer<Integer>() {
+        MemoryManager memoryManager = new MemoryManager(memoryAllocator);
 
-      @Override
-      public void serialize(Integer obj, ByteBuffer targetBuffer) {
-        targetBuffer.putInt(targetBuffer.position(), obj);
-      }
+        return new OakMap<>(
+                minKey,
+                keySerializer,
+                valueSerializer,
+                comparator, chunkMaxItems,
+                memoryManager);
+    }
 
-      @Override
-      public Integer deserialize(ByteBuffer serializedObj) {
-        return serializedObj.getInt(serializedObj.position());
-      }
-
-      @Override
-      public int calculateSize(Integer key) { return Integer.BYTES; }
-
-    };
-
-    OakSerializer<Integer> serializerV = new OakSerializer<Integer>() {
-
-      @Override
-      public void serialize(Integer obj, ByteBuffer targetBuffer) {
-        targetBuffer.putInt(targetBuffer.position(), obj);
-      }
-
-      @Override
-      public Integer deserialize(ByteBuffer serializedObj) {
-        return serializedObj.getInt(serializedObj.position());
-      }
-
-      @Override
-      public int calculateSize(Integer key) { return Integer.BYTES; }
-
-    };
-
-    OakComparator<Integer> comparator = new OakComparator<Integer>() {
-
-      @Override
-      public int compareKeys(Integer key1, Integer key2) {
-        return intsCompare(key1, key2);
-      }
-
-      @Override
-      public int compareSerializedKeys(ByteBuffer serializedKey1, ByteBuffer serializedKey2) {
-        int int1 = serializedKey1.getInt(serializedKey1.position());
-        int int2 = serializedKey2.getInt(serializedKey2.position());
-        return intsCompare(int1, int2);
-      }
-
-      @Override
-      public int compareSerializedKeyAndKey(ByteBuffer serializedKey, Integer key) {
-        int int1 = serializedKey.getInt(serializedKey.position());
-        return intsCompare(int1, key);
-      }
-    };
-
-    return new OakMapBuilder<Integer, Integer>()
-            .setKeySerializer(serializerK)
-            .setValueSerializer(serializerV)
-            .setMinKey(Integer.MIN_VALUE)
-            .setComparator(comparator);
-  }
 }

--- a/core/src/main/java/com/oath/oak/Rebalancer.java
+++ b/core/src/main/java/com/oath/oak/Rebalancer.java
@@ -16,10 +16,10 @@ class Rebalancer<K, V> {
 
     /*-------------- Constants --------------*/
 
-    private final int rebalanceSize = 2;
-    private final double maxAfterMergePart = 0.7;
-    private final double lowThreshold = 0.5;
-    private final double appendThreshold = 0.2;
+    private static final int REBALANCE_SIZE = 2;
+    private static final double MAX_AFTER_MERGE_PART = 0.7;
+    private static final double LOW_THRESHOLD = 0.5;
+    private static final double APPEND_THRESHOLD = 0.2;
 
     private final int entriesLowThreshold;
     private final int maxRangeToAppend;
@@ -43,9 +43,9 @@ class Rebalancer<K, V> {
 
     Rebalancer(Chunk<K, V> chunk, boolean offHeap, MemoryManager memoryManager,
                OakSerializer<K> keySerializer, OakSerializer<V> valueSerializer) {
-        this.entriesLowThreshold = (int) (chunk.getMaxItems() * this.lowThreshold);
-        this.maxRangeToAppend = (int) (chunk.getMaxItems() * this.appendThreshold);
-        this.maxAfterMergeItems = (int) (chunk.getMaxItems() * this.maxAfterMergePart);
+        this.entriesLowThreshold = (int) (chunk.getMaxItems() * LOW_THRESHOLD);
+        this.maxRangeToAppend = (int) (chunk.getMaxItems() * APPEND_THRESHOLD);
+        this.maxAfterMergeItems = (int) (chunk.getMaxItems() * MAX_AFTER_MERGE_PART);
         this.offHeap = offHeap;
         this.memoryManager = memoryManager;
         nextToEngage = new AtomicReference<>(chunk);
@@ -69,7 +69,7 @@ class Rebalancer<K, V> {
 
     /*-------------- Methods --------------*/
 
-    Rebalancer<K,V> engageChunks() {
+    Rebalancer<K, V> engageChunks() {
         while (true) {
             Chunk<K, V> next = nextToEngage.get();
             if (next == null) {
@@ -99,7 +99,7 @@ class Rebalancer<K, V> {
 
     /**
      * Freeze the engaged chunks. Should be called after engageChunks.
-     * Marks chunks as freezed, prevents future updates of the engagead chunks
+     * Marks chunks as frozen, prevents future updates of the engaged chunks
      */
     void freeze() {
         if (frozen.get()) {
@@ -151,7 +151,7 @@ class Rebalancer<K, V> {
                 currFrozen = iterFrozen.next();
                 ei = currFrozen.getFirstItemEntryIndex();
 
-            } else { // filled new chunk up to ENETRIES_LOW_THRESHOLD
+            } else { // filled new chunk up to entriesLowThreshold
 
                 List<Chunk<K, V>> frozenSuffix = frozenChunks.subList(iterFrozen.previousIndex(), frozenChunks.size());
                 // try to look ahead and add frozen suffix
@@ -228,7 +228,7 @@ class Rebalancer<K, V> {
         updateRangeView();
 
         // allow up to RebalanceSize chunks to be engaged
-        if (chunksInRange >= rebalanceSize) {
+        if (chunksInRange >= REBALANCE_SIZE) {
             return null;
         }
 

--- a/core/src/main/java/com/oath/oak/Rebalancer.java
+++ b/core/src/main/java/com/oath/oak/Rebalancer.java
@@ -16,14 +16,16 @@ class Rebalancer<K, V> {
 
     /*-------------- Constants --------------*/
 
-    private final int rebalanceSize;
-    private final double maxAfterMergePart;
-    private final double lowThreshold;
-    private final double appendThreshold;
+    private final int rebalanceSize = 2;
+    private final double maxAfterMergePart = 0.7;
+    private final double lowThreshold = 0.5;
+    private final double appendThreshold = 0.2;
+
     private final int entriesLowThreshold;
     private final int maxRangeToAppend;
     private final int maxAfterMergeItems;
 
+    /*-------------- Members --------------*/
     private final AtomicReference<Chunk<K, V>> nextToEngage;
     private final AtomicReference<List<Chunk<K, V>>> newChunks = new AtomicReference<>(null);
     private final AtomicReference<List<Chunk<K, V>>> engagedChunks = new AtomicReference<>(null);
@@ -32,7 +34,6 @@ class Rebalancer<K, V> {
     private Chunk<K, V> last;
     private int chunksInRange;
     private int itemsInRange;
-    private final Comparator<Object> comparator;
     private final boolean offHeap;
     private final MemoryManager memoryManager;
     private final OakSerializer<K> keySerializer;
@@ -40,16 +41,11 @@ class Rebalancer<K, V> {
 
     /*-------------- Constructors --------------*/
 
-    Rebalancer(Chunk<K, V> chunk, Comparator<Object> comparator, boolean offHeap, MemoryManager memoryManager,
+    Rebalancer(Chunk<K, V> chunk, boolean offHeap, MemoryManager memoryManager,
                OakSerializer<K> keySerializer, OakSerializer<V> valueSerializer) {
-        this.rebalanceSize = 2;
-        this.maxAfterMergePart = 0.7;
-        this.lowThreshold = 0.5;
-        this.appendThreshold = 0.2;
         this.entriesLowThreshold = (int) (chunk.getMaxItems() * this.lowThreshold);
         this.maxRangeToAppend = (int) (chunk.getMaxItems() * this.appendThreshold);
         this.maxAfterMergeItems = (int) (chunk.getMaxItems() * this.maxAfterMergePart);
-        this.comparator = comparator;
         this.offHeap = offHeap;
         this.memoryManager = memoryManager;
         nextToEngage = new AtomicReference<>(chunk);
@@ -73,14 +69,7 @@ class Rebalancer<K, V> {
 
     /*-------------- Methods --------------*/
 
-    /**
-     * compares ByteBuffer by calling the provided comparator
-     */
-    private int compare(Object k1, Object k2) {
-        return comparator.compare(k1, k2);
-    }
-
-    Rebalancer<K, V> engageChunks() {
+    Rebalancer<K,V> engageChunks() {
         while (true) {
             Chunk<K, V> next = nextToEngage.get();
             if (next == null) {

--- a/core/src/main/java/com/oath/oak/Result.java
+++ b/core/src/main/java/com/oath/oak/Result.java
@@ -1,16 +1,12 @@
 package com.oath.oak;
 
+/**
+ * A sum type for holding either a generic type value or a boolean flag.
+ */
 class Result<V> {
-    final V value;
-    final boolean flag;
-    final boolean hasValue;
-
-    private Result(V value, boolean flag, boolean hasValue) {
-        this.value = value;
-        this.flag = flag;
-        this.hasValue = hasValue;
-
-    }
+    final boolean hasValue;     // true if stores value, false if stores flag
+    final V value;              // stored value
+    final boolean flag;         // stored flag
 
     static <V> Result<V> withValue(V value) {
         return new Result<>(value, false, true);
@@ -20,4 +16,10 @@ class Result<V> {
         return new Result<>(null, flag, false);
     }
 
+    private Result(V value, boolean flag, boolean hasValue) {
+        this.value = value;
+        this.flag = flag;
+        this.hasValue = hasValue;
+
+    }
 }

--- a/core/src/main/java/com/oath/oak/Result.java
+++ b/core/src/main/java/com/oath/oak/Result.java
@@ -1,0 +1,23 @@
+package com.oath.oak;
+
+class Result<V> {
+    final V value;
+    final boolean flag;
+    final boolean hasValue;
+
+    private Result(V value, boolean flag, boolean hasValue) {
+        this.value = value;
+        this.flag = flag;
+        this.hasValue = hasValue;
+
+    }
+
+    static <V> Result<V> withValue(V value) {
+        return new Result<>(value, false, true);
+    }
+
+    static <V> Result<V> withFlag(boolean flag) {
+        return new Result<>(null, flag, false);
+    }
+
+}

--- a/core/src/main/java/com/oath/oak/ZeroCopyMap.java
+++ b/core/src/main/java/com/oath/oak/ZeroCopyMap.java
@@ -76,11 +76,11 @@ public interface ZeroCopyMap<K, V> {
      * with a value, associate it with a constructed value.
      * Else, updates the value for the specified key.
      *
-     * @param key         key with which the specified value is to be associated
-     * @param value       value to be associated with the specified key
-     * @param computer    for computing the new value when the key is present
+     * @param key      key with which the specified value is to be associated
+     * @param value    value to be associated with the specified key
+     * @param computer for computing the new value when the key is present
      * @return {@code true} if there was no mapping for the key
-     * @throws NullPointerException if any of the parameters is null
+     * @throws NullPointerException     if any of the parameters is null
      * @throws IllegalArgumentException if the specified key is out of bounds
      */
     boolean putIfAbsentComputeIfPresent(K key, V value, Consumer<OakWBuffer> computer);
@@ -115,7 +115,7 @@ public interface ZeroCopyMap<K, V> {
      * serialized keys stored in this map. When set is iterated it gives a "stream" view
      * on the elements, meaning only one element can be observed at a time.
      * The set iteration can not be shared between multi threads.
-     *
+     * <p>
      * The stream iterator is intended to be used in threads that are for iterations only
      * and are not involved in concurrent/parallel reading/updating the mappings
      *
@@ -128,7 +128,7 @@ public interface ZeroCopyMap<K, V> {
      * serialized values stored in this map. When set is iterated it gives a "stream" view
      * on the elements, meaning only one element can be observed at a time.
      * The set iteration can not be shared between multi threads.
-     *
+     * <p>
      * The stream iterator is intended to be used in threads that are for iterations only
      * and are not involved in concurrent/parallel reading/updating the mappings
      *
@@ -141,7 +141,7 @@ public interface ZeroCopyMap<K, V> {
      * map. When set is iterated it gives a "stream" view
      * on the elements, meaning only one element can be observed at a time.
      * The set iteration can not be shared between multi threads.
-     *
+     * <p>
      * The stream iterator is intended to be used in threads that are for iterations only
      * and are not involved in concurrent/parallel reading/updating the mappings
      *

--- a/core/src/main/java/com/oath/oak/ZeroCopyMap.java
+++ b/core/src/main/java/com/oath/oak/ZeroCopyMap.java
@@ -44,7 +44,7 @@ public interface ZeroCopyMap<K, V> {
      * @throws NullPointerException     if the specified key is null
      * @throws IllegalArgumentException if the specified key is out of bounds
      */
-    void remove(Object key);
+    void remove(K key);
 
     /**
      * If the specified key is not already associated

--- a/core/src/test/java/com/oath/oak/ComputeTest.java
+++ b/core/src/test/java/com/oath/oak/ComputeTest.java
@@ -106,8 +106,8 @@ public class ComputeTest {
         }
 
         @Override
-        public int compareSerializedKeyAndKey(ByteBuffer serializedKey, ByteBuffer key) {
-            return compareKeys(serializedKey, key);
+        public int compareKeyAndSerializedKey(ByteBuffer key, ByteBuffer serializedKey) {
+            return compareKeys(key, serializedKey);
         }
     }
 

--- a/core/src/test/java/com/oath/oak/FillTest.java
+++ b/core/src/test/java/com/oath/oak/FillTest.java
@@ -118,8 +118,7 @@ public class FillTest {
     @Test
     public void testMain() throws InterruptedException {
 
-        OakMapBuilder<Integer, Integer> builder = OakMapBuilder
-                .getDefaultBuilder()
+        OakMapBuilder<Integer, Integer> builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(2048)
                 .setKeySerializer(new FillTestKeySerializer())
                 .setValueSerializer(new FillTestValueSerializer());

--- a/core/src/test/java/com/oath/oak/HeapUsageTest.java
+++ b/core/src/test/java/com/oath/oak/HeapUsageTest.java
@@ -58,8 +58,7 @@ public class HeapUsageTest {
     @Test
     public void testMain() throws InterruptedException {
 
-        OakMapBuilder<Integer, Integer> builder = OakMapBuilder
-                .getDefaultBuilder()
+        OakMapBuilder builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(2048)
                 .setKeySerializer(new FillTestKeySerializer())
                 .setValueSerializer(new FillTestValueSerializer());

--- a/core/src/test/java/com/oath/oak/IntegerOakMap.java
+++ b/core/src/test/java/com/oath/oak/IntegerOakMap.java
@@ -19,9 +19,9 @@ public class IntegerOakMap {
         }
 
         @Override
-        public int compareSerializedKeyAndKey(ByteBuffer serializedKey, Integer key) {
+        public int compareKeyAndSerializedKey(Integer key, ByteBuffer serializedKey) {
             int int1 = serializedKey.getInt(serializedKey.position());
-            return intsCompare(int1, key);
+            return intsCompare(key, int1);
         }
     };
 

--- a/core/src/test/java/com/oath/oak/IntegerOakMap.java
+++ b/core/src/test/java/com/oath/oak/IntegerOakMap.java
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer;
 
 public class IntegerOakMap {
 
-    public static OakComparator<Integer> comparator = new OakComparator<Integer>() {
+    static OakComparator<Integer> comparator = new OakComparator<Integer>() {
 
         @Override
         public int compareKeys(Integer key1, Integer key2) {
@@ -25,7 +25,7 @@ public class IntegerOakMap {
         }
     };
 
-    public static OakSerializer<Integer> serializer = new OakSerializer<Integer>() {
+    static OakSerializer<Integer> serializer = new OakSerializer<Integer>() {
 
         @Override
         public void serialize(Integer obj, ByteBuffer targetBuffer) {
@@ -38,7 +38,9 @@ public class IntegerOakMap {
         }
 
         @Override
-        public int calculateSize(Integer key) { return Integer.BYTES; }
+        public int calculateSize(Integer key) {
+            return Integer.BYTES;
+        }
 
     };
 

--- a/core/src/test/java/com/oath/oak/InternalOakMapTest.java
+++ b/core/src/test/java/com/oath/oak/InternalOakMapTest.java
@@ -8,8 +8,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 public class InternalOakMapTest {
 
@@ -58,7 +57,7 @@ public class InternalOakMapTest {
 
         final Integer[] results = new Integer[3];
 
-        List<Thread> threadList = new ArrayList<>(3);
+        List<Thread> threadList = new ArrayList<>(results.length);
         threadList.add(new Thread(() -> results[0] = testMap.put(k, v1, IntegerOakMap.serializer::deserialize)));
         threadList.add(new Thread(() -> results[1] = testMap.put(k, v2, InternalOakMapTest::slowDeserialize)));
         threadList.add(new Thread(() -> results[2] = testMap.put(k, v3, IntegerOakMap.serializer::deserialize)));
@@ -77,7 +76,7 @@ public class InternalOakMapTest {
 
         final Integer[] results = new Integer[3];
 
-        List<Thread> threadList = new ArrayList<>(3);
+        List<Thread> threadList = new ArrayList<>(results.length);
         threadList.add(new Thread(() -> results[0] = testMap.put(k, v1, IntegerOakMap.serializer::deserialize)));
         threadList.add(new Thread(() -> results[1] = testMap.remove(k, null, InternalOakMapTest::slowDeserialize)));
         threadList.add(new Thread(() -> results[2] = testMap.put(k, v2, IntegerOakMap.serializer::deserialize)));
@@ -97,7 +96,7 @@ public class InternalOakMapTest {
 
         testMap.put(k, v1, IntegerOakMap.serializer::deserialize);
 
-        List<Thread> threadList = new ArrayList<>(3);
+        List<Thread> threadList = new ArrayList<>(results.length);
         threadList.add(new Thread(() -> results[0] = testMap.remove(k, null, InternalOakMapTest::slowDeserialize)));
         threadList.add(new Thread(() -> results[1] = testMap.remove(k, null, IntegerOakMap.serializer::deserialize)));
 

--- a/core/src/test/java/com/oath/oak/InternalOakMapTest.java
+++ b/core/src/test/java/com/oath/oak/InternalOakMapTest.java
@@ -1,0 +1,108 @@
+package com.oath.oak;
+
+import com.oath.oak.NativeAllocator.OakNativeMemoryAllocator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+public class InternalOakMapTest {
+
+    private InternalOakMap<Integer, Integer> testMap;
+
+    private static final long operationDelay = 100;
+    private static final long longTransformationDelay = 1000;
+
+    @Before
+    public void setUp() {
+        MemoryManager memoryManager = new MemoryManager(new OakNativeMemoryAllocator(128));
+        int chunkMaxItems = 100;
+
+        testMap = new InternalOakMap<>(Integer.MIN_VALUE, IntegerOakMap.serializer, IntegerOakMap.serializer, IntegerOakMap.comparator,
+                memoryManager, chunkMaxItems);
+    }
+
+
+    private static Integer slowDeserialize(ByteBuffer bb) {
+        try {
+            Thread.sleep(longTransformationDelay);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        return IntegerOakMap.serializer.deserialize(bb);
+    }
+
+    private void runThreads(List<Thread> threadList) throws InterruptedException {
+        for (Thread thread : threadList) {
+            thread.start();
+            Thread.sleep(operationDelay);
+        }
+
+        for (Thread thread : threadList) {
+            thread.join();
+        }
+    }
+
+
+    @Test
+    public void concurrentPuts() throws InterruptedException {
+        Integer k = 1;
+        Integer v1 = 1;
+        Integer v2 = 2;
+        Integer v3 = 3;
+
+        final Integer[] results = new Integer[3];
+
+        List<Thread> threadList = new ArrayList<>(3);
+        threadList.add(new Thread(() -> results[0] = testMap.put(k, v1, IntegerOakMap.serializer::deserialize)));
+        threadList.add(new Thread(() -> results[1] = testMap.put(k, v2, InternalOakMapTest::slowDeserialize)));
+        threadList.add(new Thread(() -> results[2] = testMap.put(k, v3, IntegerOakMap.serializer::deserialize)));
+
+        runThreads(threadList);
+
+        assertNull(results[0]);
+        assertNotEquals(results[1], results[2]);
+    }
+
+    @Test
+    public void concurrentPutAndRemove() throws InterruptedException {
+        Integer k = 1;
+        Integer v1 = 1;
+        Integer v2 = 2;
+
+        final Integer[] results = new Integer[3];
+
+        List<Thread> threadList = new ArrayList<>(3);
+        threadList.add(new Thread(() -> results[0] = testMap.put(k, v1, IntegerOakMap.serializer::deserialize)));
+        threadList.add(new Thread(() -> results[1] = testMap.remove(k, null, InternalOakMapTest::slowDeserialize)));
+        threadList.add(new Thread(() -> results[2] = testMap.put(k, v2, IntegerOakMap.serializer::deserialize)));
+
+        runThreads(threadList);
+
+        assertNull(results[0]);
+        assertNotEquals(results[1], results[2]);
+    }
+
+    @Test
+    public void concurrentRemove() throws InterruptedException {
+        Integer k = 1;
+        Integer v1 = 1;
+
+        final Integer[] results = new Integer[2];
+
+        testMap.put(k, v1, IntegerOakMap.serializer::deserialize);
+
+        List<Thread> threadList = new ArrayList<>(3);
+        threadList.add(new Thread(() -> results[0] = testMap.remove(k, null, InternalOakMapTest::slowDeserialize)));
+        threadList.add(new Thread(() -> results[1] = testMap.remove(k, null, IntegerOakMap.serializer::deserialize)));
+
+        runThreads(threadList);
+
+        assertNotEquals(results[0], results[1]);
+    }
+}

--- a/core/src/test/java/com/oath/oak/MultiThreadComputeTest.java
+++ b/core/src/test/java/com/oath/oak/MultiThreadComputeTest.java
@@ -30,7 +30,7 @@ public class MultiThreadComputeTest {
 
     @Before
     public void init() {
-        OakMapBuilder<Integer, Integer> builder = OakMapBuilder.getDefaultBuilder()
+        OakMapBuilder<Integer, Integer> builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(maxItemsPerChunk);
         oak = builder.build();
         latch = new CountDownLatch(1);

--- a/core/src/test/java/com/oath/oak/MultiThreadRangeTest.java
+++ b/core/src/test/java/com/oath/oak/MultiThreadRangeTest.java
@@ -27,7 +27,7 @@ public class MultiThreadRangeTest {
 
     @Before
     public void init() {
-        OakMapBuilder<Integer, Integer> builder = OakMapBuilder.getDefaultBuilder()
+        OakMapBuilder<Integer, Integer>builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(maxItemsPerChunk);
         oak = builder.build();
         latch = new CountDownLatch(1);

--- a/core/src/test/java/com/oath/oak/MultiThreadTest.java
+++ b/core/src/test/java/com/oath/oak/MultiThreadTest.java
@@ -34,7 +34,7 @@ public class MultiThreadTest {
 
     @Before
     public void init() {
-        OakMapBuilder<Integer, Integer> builder = OakMapBuilder.getDefaultBuilder()
+        OakMapBuilder<Integer, Integer> builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(maxItemsPerChunk);
         oak = builder.build();
         latch = new CountDownLatch(1);

--- a/core/src/test/java/com/oath/oak/NativeAllocator/OakNativeMemoryAllocatorTest.java
+++ b/core/src/test/java/com/oath/oak/NativeAllocator/OakNativeMemoryAllocatorTest.java
@@ -1,9 +1,5 @@
 package com.oath.oak.NativeAllocator;
 
-import com.oath.oak.OakMap;
-import com.oath.oak.OakMapBuilder;
-import com.oath.oak.OakOutOfMemoryException;
-import com.oath.oak.OakSerializer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,7 +9,11 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import com.oath.oak.ThreadIndexCalculator;
+import com.oath.oak.IntegerOakMap;
+import com.oath.oak.OakMap;
+import com.oath.oak.OakMapBuilder;
+import com.oath.oak.OakOutOfMemoryException;
+import com.oath.oak.OakSerializer;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertNull;
@@ -132,7 +132,7 @@ public class OakNativeMemoryAllocatorTest {
         int keysSizeAfterSerialization;
         OakNativeMemoryAllocator ma = new OakNativeMemoryAllocator(capacity);
         int maxItemsPerChunk = 1024;
-        OakMapBuilder<Integer, Integer> builder = OakMapBuilder.getDefaultBuilder()
+        OakMapBuilder<Integer, Integer> builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(maxItemsPerChunk)
                 .setValueSerializer(new CheckOakCapacityValueSerializer())
                 .setMemoryAllocator(ma);

--- a/core/src/test/java/com/oath/oak/OakMapApiTest.java
+++ b/core/src/test/java/com/oath/oak/OakMapApiTest.java
@@ -20,7 +20,7 @@ public class OakMapApiTest {
     @Before
     public void init() {
         int maxItemsPerChunk = 2048;
-        OakMapBuilder<Integer, Integer> builder = OakMapBuilder.getDefaultBuilder()
+        OakMapBuilder<Integer, Integer> builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(maxItemsPerChunk);
         oak = builder.build();
     }

--- a/core/src/test/java/com/oath/oak/OakMapApiTest.java
+++ b/core/src/test/java/com/oath/oak/OakMapApiTest.java
@@ -293,6 +293,25 @@ public class OakMapApiTest {
         }
     }
 
+    @Test
+    public void descIterTest() {
+        int numKeys = 10;
+        for (int i = 0; i < numKeys; i++) {
+            oak.put(i, i);
+        }
+
+        Integer from = 4;
+        Integer to = 6;
+
+        int expected = to;
+        try (OakMap<Integer, Integer> sub = oak.subMap(from, false, to, true).descendingMap()) {
+            for (Integer i : sub.values()) {
+                assertEquals(expected, i.intValue());
+                expected--;
+            }
+        }
+    }
+
     @Test(expected = ReadOnlyBufferException.class)
     public void immutableKeyBuffers() {
         oak.put(0, 0);

--- a/core/src/test/java/com/oath/oak/PutIfAbsentTest.java
+++ b/core/src/test/java/com/oath/oak/PutIfAbsentTest.java
@@ -27,7 +27,7 @@ public class PutIfAbsentTest {
 
     @Before
     public void init() {
-        OakMapBuilder<Integer, Integer> builder = OakMapBuilder.getDefaultBuilder();
+        OakMapBuilder<Integer, Integer> builder = IntegerOakMap.getDefaultBuilder();
         oak = builder.build();
         startSignal = new CountDownLatch(1);
         threads = new ArrayList<>(NUM_THREADS);

--- a/core/src/test/java/com/oath/oak/SingleThreadIteratorTest.java
+++ b/core/src/test/java/com/oath/oak/SingleThreadIteratorTest.java
@@ -25,7 +25,8 @@ public class SingleThreadIteratorTest {
 
     @Before
     public void init() {
-        OakMapBuilder<Integer, Integer> builder = OakMapBuilder.getDefaultBuilder()
+        int maxBytesPerChunkItem = 100;
+        OakMapBuilder<Integer, Integer> builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(maxItemsPerChunk);
         oak = builder.build();
     }
@@ -360,7 +361,7 @@ public class SingleThreadIteratorTest {
                     ByteBuffer bb = ByteBuffer.allocate(4);
                     bb.putInt(i);
                     bb.flip();
-                    sub.zc().remove(bb);
+                    sub.zc().remove(i);
                 }
             }
 

--- a/core/src/test/java/com/oath/oak/SingleThreadIteratorTest.java
+++ b/core/src/test/java/com/oath/oak/SingleThreadIteratorTest.java
@@ -25,7 +25,6 @@ public class SingleThreadIteratorTest {
 
     @Before
     public void init() {
-        int maxBytesPerChunkItem = 100;
         OakMapBuilder<Integer, Integer> builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(maxItemsPerChunk);
         oak = builder.build();

--- a/core/src/test/java/com/oath/oak/SingleThreadTest.java
+++ b/core/src/test/java/com/oath/oak/SingleThreadTest.java
@@ -22,7 +22,6 @@ public class SingleThreadTest {
 
     @Before
     public void init() {
-        int maxBytesPerChunkItem = Integer.BYTES;
         OakMapBuilder<Integer, Integer> builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(maxItemsPerChunk);
         oak = builder.build();

--- a/core/src/test/java/com/oath/oak/SingleThreadTest.java
+++ b/core/src/test/java/com/oath/oak/SingleThreadTest.java
@@ -22,7 +22,8 @@ public class SingleThreadTest {
 
     @Before
     public void init() {
-        OakMapBuilder<Integer, Integer> builder = OakMapBuilder.getDefaultBuilder()
+        int maxBytesPerChunkItem = Integer.BYTES;
+        OakMapBuilder<Integer, Integer> builder = IntegerOakMap.getDefaultBuilder()
                 .setChunkMaxItems(maxItemsPerChunk);
         oak = builder.build();
     }

--- a/core/src/test/java/com/oath/oak/StringComparator.java
+++ b/core/src/test/java/com/oath/oak/StringComparator.java
@@ -36,14 +36,14 @@ public class StringComparator implements OakComparator<String>{
     }
 
     @Override
-    public int compareSerializedKeyAndKey(ByteBuffer serializedKey, String key) {
-        int size1 = serializedKey.getInt(serializedKey.position());
-        int size2 = key.length();
+    public int compareKeyAndSerializedKey(String key, ByteBuffer serializedKey) {
+        int size1 = key.length();
+        int size2 = serializedKey.getInt(serializedKey.position());
 
         int it=0;
         while (it < size1 && it < size2) {
-            char c1 = serializedKey.getChar(Integer.BYTES + serializedKey.position() + it*Character.BYTES);
-            char c2 = key.charAt(it);
+            char c1 = key.charAt(it);
+            char c2 = serializedKey.getChar(Integer.BYTES + serializedKey.position() + it * Character.BYTES);
             int compare = Character.compare(c1, c2);
             if (compare != 0) {
                 return compare;

--- a/core/src/test/java/com/oath/oak/UnsafeUtilsTest.java
+++ b/core/src/test/java/com/oath/oak/UnsafeUtilsTest.java
@@ -1,10 +1,8 @@
 package com.oath.oak;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -134,12 +132,12 @@ public class UnsafeUtilsTest {
         @Override
         public int compareSerializedKeys(ByteBuffer serializedKey1, ByteBuffer serializedKey2) {
             return compareKeys(new UnsafeTestSerializer().deserialize(serializedKey1),
-                    new UnsafeTestSerializer().deserialize(serializedKey1));
+                    new UnsafeTestSerializer().deserialize(serializedKey2));
         }
 
         @Override
-        public int compareSerializedKeyAndKey(ByteBuffer serializedKey, IntHolder key) {
-            return compareKeys(new UnsafeTestSerializer().deserialize(serializedKey), key);
+        public int compareKeyAndSerializedKey(IntHolder key, ByteBuffer serializedKey) {
+            return compareKeys(key, new UnsafeTestSerializer().deserialize(serializedKey));
         }
     }
 


### PR DESCRIPTION
**UPDATED 2019-09-23**
- Bug fixes
  - putIfAbsent may return null instead of value for existing keys
  - Logical deletion in remove was not marked properly
  - Fix Non-ZC concurrent put
    - Move desrialization to an atomic value exchange method in Handle
  - Fix Non-ZC concurrent removals
    - Move desrialization to an atomic remove in Handle

- Other improvements
  - Some improvements to type safety in InternalOakMap and relatives (mostly trying to reduce fallout from mixed skiplist comparator and make comparator usage safer)
  - Refactor Integer OakMap reference implementation to a new class so that serializer and comparator can be reused
  - Pulled up Result class to top level so that it can be used in Handle as well
  - Fixed: OffHeapOakTest fails silently because JUnit doesn't fail on thread exceptions
    - Fail test when exceptions occur in threads

---

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
