### PR TITLE
fixed bug causing IndexOutOfBoundsException

### DIFF
--- a/core/src/main/java/com/oath/oak/Chunk.java
+++ b/core/src/main/java/com/oath/oak/Chunk.java
@@ -712,7 +712,7 @@ public class Chunk<K, V> {
             // try to find a continuous interval to copy
             // we cannot enlarge interval: if key is removed (handle index is -1) or
             // if this chunk already has all entries to start with
-            if ((currSrcHandleIndex > 0) && (!isHandleDeleted) && (sortedEntryIndex + entriesToCopy * FIELDS <= maxIdx)) {
+            if ((currSrcHandleIndex > 0) && (!isHandleDeleted) && (sortedEntryIndex + entriesToCopy * FIELDS < maxIdx)) {
                 // we can enlarge the interval, if it is otherwise possible:
                 // if this is first entry in the interval (we need to copy one entry anyway) OR
                 // if (on the source chunk) current entry idx directly follows the previous entry idx
@@ -760,7 +760,7 @@ public class Chunk<K, V> {
                 srcEntryIdx = srcChunk.getEntryField(srcEntryIdx, OFFSET_NEXT);
             }
 
-            if (srcEntryIdx == NONE || sortedEntryIndex > maxIdx)
+            if (srcEntryIdx == NONE || sortedEntryIndex >= maxIdx)
                 break; // if we are done
 
             // reset and continue


### PR DESCRIPTION
The rebalancer used to copy an additional entry, one more than `maxCapacity`.
Once in a while, an IndexOutOfBoundsException is thrown when copying entries from one chunk to another.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
