### PR TITLE
Removing ThreadLocal from ThreadIndexCalculator

### DIFF
--- a/core/src/main/java/com/oath/oak/ThreadIndexCalculator.java
+++ b/core/src/main/java/com/oath/oak/ThreadIndexCalculator.java
@@ -1,41 +1,62 @@
 
 package com.oath.oak;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class ThreadIndexCalculator {
 
     public static final int MAX_THREADS = 32;
     private static final int INVALID_THREAD_ID = -1;
-    private ThreadLocal<Integer> local = ThreadLocal.withInitial(() -> INVALID_THREAD_ID);
-    private AtomicInteger[] indices = new AtomicInteger[MAX_THREADS];
+    // Long for correctness and anti false-sharing
+    private AtomicLong[] indices = new AtomicLong[MAX_THREADS];
 
     private ThreadIndexCalculator() {
         for (int i = 0; i < MAX_THREADS; ++i) {
-            indices[i] = new AtomicInteger(INVALID_THREAD_ID);
+            indices[i] = new AtomicLong(INVALID_THREAD_ID);
         }
     }
 
+    private int getExistingIndex(long threadID){
+      int iterationCnt = 0;
+      int currentIndex = ((int)threadID) % MAX_THREADS;
+      long currentThreadID = indices[currentIndex].get();
+      while (currentThreadID != threadID) {
+        if (currentThreadID == INVALID_THREAD_ID) {
+          return -1*currentIndex;
+        }
+        currentIndex = (currentIndex + 1) % MAX_THREADS;
+        currentThreadID = indices[currentIndex].get();
+        iterationCnt++;
+        assert iterationCnt<MAX_THREADS;
+      }
+      return currentIndex;
+    }
 
     public int getIndex() {
-
-        int localInt = local.get();
-        if (localInt != INVALID_THREAD_ID) {
-            return localInt;
+        long tid = Thread.currentThread().getId();
+        int threadIdx = getExistingIndex(tid);
+        if (threadIdx > 0) {
+            return threadIdx;
         }
-        int tid = (int) Thread.currentThread().getId();
-        int i = tid % MAX_THREADS;
+        if (threadIdx == 0) {
+          // due to multiplying by -1 check this special array element
+          if (tid == indices[0].get()) {
+            return threadIdx;
+          }
+        }
+        int i = threadIdx*-1;
         while (!indices[i].compareAndSet(INVALID_THREAD_ID, tid)) {
             //TODO get out of loop sometime
             i = (i + 1) % MAX_THREADS;
         }
-        local.set(i);
         return i;
     }
 
     public void releaseIndex() {
-        indices[local.get()].set(INVALID_THREAD_ID);
-        local.set(INVALID_THREAD_ID);
+        long tid = Thread.currentThread().getId();
+        int index = getExistingIndex(tid);
+        assert index >=0 ;
+        indices[index].set(INVALID_THREAD_ID);
     }
 
     public static ThreadIndexCalculator newInstance() {

--- a/core/src/main/java/com/oath/oak/ThreadIndexCalculator.java
+++ b/core/src/main/java/com/oath/oak/ThreadIndexCalculator.java
@@ -1,6 +1,7 @@
 
 package com.oath.oak;
 
+import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ThreadIndexCalculator {
@@ -22,6 +23,7 @@ public class ThreadIndexCalculator {
       long currentThreadID = indices[currentIndex].get();
       while (currentThreadID != threadID) {
         if (currentThreadID == INVALID_THREAD_ID) {
+          // negative output indicates that a new index need to be created for this thread id
           return -1*currentIndex;
         }
         currentIndex = (currentIndex + 1) % MAX_THREADS;
@@ -56,6 +58,11 @@ public class ThreadIndexCalculator {
         long tid = Thread.currentThread().getId();
         int index = getExistingIndex(tid);
         assert index >=0 ;
+        if (index < 0) {
+          // There is no such thread index in the calculator, so throw NoSuchElementException
+          // Probably releasing the same thread twice
+          throw new NoSuchElementException();
+        }
         indices[index].set(INVALID_THREAD_ID);
     }
 

--- a/core/src/test/java/com/oath/oak/HeapUsageTest.java
+++ b/core/src/test/java/com/oath/oak/HeapUsageTest.java
@@ -69,7 +69,7 @@ public class HeapUsageTest {
         // this number can be changed to test larger sizes however JVM memory limit need to be changed
         // otherwise this will hit "java.lang.OutOfMemoryError: Direct buffer memory" exception
         // currently tested up to 2GB
-        int numOfEntries = 360000;
+        int numOfEntries = 160000;
 
         //System.out.println("key size: " + keySize + "B" + ", value size: " + ((double) valSize) / K + "KB");
 


### PR DESCRIPTION
Removing usage of ThreadLocal from ThreadIndexCalculator. The tests are passing. Synchrobench zero-copy gets-only benchmark show a small 5% performance improvement.



<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
