### PR TITLE
Limit OakMapBuilder to build an Oak only with valid comparator

### DIFF
--- a/benchmarks/jmh/src/main/java/com/oath/oak/GetBenchmark.java
+++ b/benchmarks/jmh/src/main/java/com/oath/oak/GetBenchmark.java
@@ -45,10 +45,9 @@ public class GetBenchmark {
         @Setup()
         public void setup() {
 
-            OakMapBuilder<String, String> builder = new OakMapBuilder<String, String>()
-                    .setKeySerializer(new StringSerializer())
-                    .setValueSerializer(new StringSerializer())
-                    .setComparator(new StringComparator())
+            OakMapBuilder<String, String> builder =
+                new OakMapBuilder<String, String>(
+                    new StringComparator(), new StringSerializer(), new StringSerializer())
                     .setMinKey("");
 
             oakMap = builder.build();

--- a/benchmarks/jmh/src/main/java/com/oath/oak/GetBenchmark.java
+++ b/benchmarks/jmh/src/main/java/com/oath/oak/GetBenchmark.java
@@ -47,8 +47,8 @@ public class GetBenchmark {
 
             OakMapBuilder<String, String> builder =
                 new OakMapBuilder<String, String>(
-                    new StringComparator(), new StringSerializer(), new StringSerializer())
-                    .setMinKey("");
+                    new StringComparator(),
+                    new StringSerializer(), new StringSerializer(),"");
 
             oakMap = builder.build();
 

--- a/benchmarks/jmh/src/main/java/com/oath/oak/PutBenchmark.java
+++ b/benchmarks/jmh/src/main/java/com/oath/oak/PutBenchmark.java
@@ -47,8 +47,7 @@ public class PutBenchmark {
 
             OakMapBuilder<String, String> builder =
                 new OakMapBuilder<String, String>(
-                    new StringComparator(), new StringSerializer(), new StringSerializer())
-                    .setMinKey("");
+                    new StringComparator(), new StringSerializer(), new StringSerializer(),"");
 
             oakMap = builder.build();
         }

--- a/benchmarks/jmh/src/main/java/com/oath/oak/PutBenchmark.java
+++ b/benchmarks/jmh/src/main/java/com/oath/oak/PutBenchmark.java
@@ -45,10 +45,9 @@ public class PutBenchmark {
         @Setup(Level.Iteration)
         public void setup() {
 
-            OakMapBuilder<String, String> builder = new OakMapBuilder<String, String>()
-                    .setKeySerializer(new StringSerializer())
-                    .setValueSerializer(new StringSerializer())
-                    .setComparator(new StringComparator())
+            OakMapBuilder<String, String> builder =
+                new OakMapBuilder<String, String>(
+                    new StringComparator(), new StringSerializer(), new StringSerializer())
                     .setMinKey("");
 
             oakMap = builder.build();

--- a/benchmarks/jmh/src/main/java/com/oath/oak/ScanBenchmark.java
+++ b/benchmarks/jmh/src/main/java/com/oath/oak/ScanBenchmark.java
@@ -53,8 +53,7 @@ public class ScanBenchmark
 
         OakMapBuilder<String, String> builder =
             new OakMapBuilder<String, String>(
-                new StringComparator(),new StringSerializer(),new StringSerializer())
-                .setMinKey("");
+                new StringComparator(),new StringSerializer(),new StringSerializer(),"");
 
         oakMap = builder.build();
 

--- a/benchmarks/jmh/src/main/java/com/oath/oak/ScanBenchmark.java
+++ b/benchmarks/jmh/src/main/java/com/oath/oak/ScanBenchmark.java
@@ -51,10 +51,9 @@ public class ScanBenchmark
     @Setup
     public void setup() {
 
-        OakMapBuilder<String, String> builder = new OakMapBuilder<String, String>()
-                .setKeySerializer(new StringSerializer())
-                .setValueSerializer(new StringSerializer())
-                .setComparator(new StringComparator())
+        OakMapBuilder<String, String> builder =
+            new OakMapBuilder<String, String>(
+                new StringComparator(),new StringSerializer(),new StringSerializer())
                 .setMinKey("");
 
         oakMap = builder.build();

--- a/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/maps/OakMap.java
+++ b/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/maps/OakMap.java
@@ -25,11 +25,10 @@ public class OakMap<K extends MyBuffer, V extends MyBuffer> implements Compositi
         }
         minKey = new MyBuffer(Integer.BYTES);
         minKey.buffer.putInt(0, Integer.MIN_VALUE);
-        builder = new OakMapBuilder<MyBuffer, MyBuffer>()
-                .setKeySerializer(MyBufferOak.serializer)
-                .setValueSerializer(MyBufferOak.serializer)
+        builder =
+            new OakMapBuilder<MyBuffer, MyBuffer>(
+                MyBufferOak.keysComparator, MyBufferOak.serializer, MyBufferOak.serializer)
                 .setMinKey(minKey)
-                .setComparator(MyBufferOak.keysComparator)
                 .setChunkMaxItems(Chunk.MAX_ITEMS_DEFAULT)
                 .setMemoryAllocator(ma);
         oak = builder.build();
@@ -134,11 +133,10 @@ public class OakMap<K extends MyBuffer, V extends MyBuffer> implements Compositi
         }
         minKey = new MyBuffer(Integer.BYTES);
         minKey.buffer.putInt(0, Integer.MIN_VALUE);
-        builder = new OakMapBuilder<MyBuffer, MyBuffer>()
-                .setKeySerializer(MyBufferOak.serializer)
-                .setValueSerializer(MyBufferOak.serializer)
+        builder =
+            new OakMapBuilder<MyBuffer, MyBuffer>(
+                MyBufferOak.keysComparator, MyBufferOak.serializer, MyBufferOak.serializer)
                 .setMinKey(minKey)
-                .setComparator(MyBufferOak.keysComparator)
                 .setChunkMaxItems(Chunk.MAX_ITEMS_DEFAULT)
                 .setMemoryAllocator(ma);
         oak = builder.build();

--- a/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/maps/OakMap.java
+++ b/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/maps/OakMap.java
@@ -27,8 +27,7 @@ public class OakMap<K extends MyBuffer, V extends MyBuffer> implements Compositi
         minKey.buffer.putInt(0, Integer.MIN_VALUE);
         builder =
             new OakMapBuilder<MyBuffer, MyBuffer>(
-                MyBufferOak.keysComparator, MyBufferOak.serializer, MyBufferOak.serializer)
-                .setMinKey(minKey)
+                MyBufferOak.keysComparator, MyBufferOak.serializer, MyBufferOak.serializer, minKey)
                 .setChunkMaxItems(Chunk.MAX_ITEMS_DEFAULT)
                 .setMemoryAllocator(ma);
         oak = builder.build();
@@ -135,8 +134,7 @@ public class OakMap<K extends MyBuffer, V extends MyBuffer> implements Compositi
         minKey.buffer.putInt(0, Integer.MIN_VALUE);
         builder =
             new OakMapBuilder<MyBuffer, MyBuffer>(
-                MyBufferOak.keysComparator, MyBufferOak.serializer, MyBufferOak.serializer)
-                .setMinKey(minKey)
+                MyBufferOak.keysComparator, MyBufferOak.serializer, MyBufferOak.serializer, minKey)
                 .setChunkMaxItems(Chunk.MAX_ITEMS_DEFAULT)
                 .setMemoryAllocator(ma);
         oak = builder.build();

--- a/core/src/main/java/com/oath/oak/OakMapBuilder.java
+++ b/core/src/main/java/com/oath/oak/OakMapBuilder.java
@@ -32,13 +32,12 @@ public class OakMapBuilder<K, V> {
     private long memoryCapacity;
     private OakBlockMemoryAllocator memoryAllocator;
 
-    public OakMapBuilder() {
-        this.keySerializer = null;
-        this.valueSerializer = null;
-
+    public OakMapBuilder(OakComparator<K> comparator, OakSerializer<K> keySerializer, OakSerializer<V> valueSerializer) {
+        this.keySerializer = keySerializer;
+        this.valueSerializer = valueSerializer;
         this.minKey = null;
 
-        this.comparator = null;
+        this.comparator = comparator;
 
         this.chunkMaxItems = Chunk.MAX_ITEMS_DEFAULT;
         this.memoryCapacity = MAX_MEM_CAPACITY;
@@ -87,7 +86,15 @@ public class OakMapBuilder<K, V> {
         }
 
         MemoryManager memoryManager = new NovaManager(memoryAllocator);
-
+        if (comparator == null) {
+            throw new IllegalStateException("Must provide a non-null comparator to build the OakMap");
+        }
+        if (keySerializer == null) {
+            throw new IllegalStateException("Must provide a non-null key serializer to build the OakMap");
+        }
+        if (valueSerializer == null) {
+            throw new IllegalStateException("Must provide a non-null value serializer to build the OakMap");
+        }
         return new OakMap<>(
                 minKey,
                 keySerializer,

--- a/core/src/main/java/com/oath/oak/OakMapBuilder.java
+++ b/core/src/main/java/com/oath/oak/OakMapBuilder.java
@@ -32,10 +32,11 @@ public class OakMapBuilder<K, V> {
     private long memoryCapacity;
     private OakBlockMemoryAllocator memoryAllocator;
 
-    public OakMapBuilder(OakComparator<K> comparator, OakSerializer<K> keySerializer, OakSerializer<V> valueSerializer) {
+    public OakMapBuilder(OakComparator<K> comparator,
+        OakSerializer<K> keySerializer, OakSerializer<V> valueSerializer, K minKey) {
         this.keySerializer = keySerializer;
         this.valueSerializer = valueSerializer;
-        this.minKey = null;
+        this.minKey = minKey;
 
         this.comparator = comparator;
 
@@ -94,6 +95,9 @@ public class OakMapBuilder<K, V> {
         }
         if (valueSerializer == null) {
             throw new IllegalStateException("Must provide a non-null value serializer to build the OakMap");
+        }
+        if (minKey == null) {
+            throw new IllegalStateException("Must provide a non-null minimal key object to build the OakMap");
         }
         return new OakMap<>(
                 minKey,

--- a/core/src/test/java/com/oath/oak/ChunkSplitTest.java
+++ b/core/src/test/java/com/oath/oak/ChunkSplitTest.java
@@ -17,9 +17,8 @@ public class ChunkSplitTest {
     public void testSplitByCount() throws NoSuchFieldException, IllegalAccessException {
         OakMapBuilder<String, String> builder =
             new OakMapBuilder<String, String>(
-                new StringComparator(), new StringSerializer(), new StringSerializer())
-                .setChunkMaxItems(maxItemsPerChunk)
-                .setMinKey("");
+                new StringComparator(), new StringSerializer(), new StringSerializer(), "")
+                .setChunkMaxItems(maxItemsPerChunk);
         OakMap<String, String> oak = builder.build();
 
         for (int i = 0; i < maxItemsPerChunk + 1; i++) {

--- a/core/src/test/java/com/oath/oak/ChunkSplitTest.java
+++ b/core/src/test/java/com/oath/oak/ChunkSplitTest.java
@@ -15,11 +15,10 @@ public class ChunkSplitTest {
 
     @Test
     public void testSplitByCount() throws NoSuchFieldException, IllegalAccessException {
-        OakMapBuilder<String, String> builder = new OakMapBuilder<String, String>()
+        OakMapBuilder<String, String> builder =
+            new OakMapBuilder<String, String>(
+                new StringComparator(), new StringSerializer(), new StringSerializer())
                 .setChunkMaxItems(maxItemsPerChunk)
-                .setKeySerializer(new StringSerializer())
-                .setValueSerializer(new StringSerializer())
-                .setComparator(new StringComparator())
                 .setMinKey("");
         OakMap<String, String> oak = builder.build();
 

--- a/core/src/test/java/com/oath/oak/ComputeTest.java
+++ b/core/src/test/java/com/oath/oak/ComputeTest.java
@@ -174,12 +174,12 @@ public class ComputeTest {
         }
         minKey.position(0);
 
-        OakMapBuilder<ByteBuffer, ByteBuffer> builder = new OakMapBuilder<ByteBuffer, ByteBuffer>()
+        OakMapBuilder<ByteBuffer, ByteBuffer> builder
+            = new OakMapBuilder<ByteBuffer, ByteBuffer>(
+                new ComputeTestComparator(), new ComputeTestKeySerializer(), new ComputeTestValueSerializer())
                 .setChunkMaxItems(2048)
-                .setKeySerializer(new ComputeTestKeySerializer())
-                .setValueSerializer(new ComputeTestValueSerializer())
                 .setMinKey(minKey)
-                .setComparator(new ComputeTestComparator());
+                ;
 
         oak = builder.build();
 

--- a/core/src/test/java/com/oath/oak/ComputeTest.java
+++ b/core/src/test/java/com/oath/oak/ComputeTest.java
@@ -176,9 +176,9 @@ public class ComputeTest {
 
         OakMapBuilder<ByteBuffer, ByteBuffer> builder
             = new OakMapBuilder<ByteBuffer, ByteBuffer>(
-                new ComputeTestComparator(), new ComputeTestKeySerializer(), new ComputeTestValueSerializer())
+                new ComputeTestComparator(),
+                new ComputeTestKeySerializer(), new ComputeTestValueSerializer(), minKey)
                 .setChunkMaxItems(2048)
-                .setMinKey(minKey)
                 ;
 
         oak = builder.build();

--- a/core/src/test/java/com/oath/oak/IntegerOakMap.java
+++ b/core/src/test/java/com/oath/oak/IntegerOakMap.java
@@ -45,11 +45,9 @@ public class IntegerOakMap {
     };
 
     public static OakMapBuilder<Integer, Integer> getDefaultBuilder() {
-        return new OakMapBuilder<Integer, Integer>()
-                .setKeySerializer(serializer)
-                .setValueSerializer(serializer)
+        return new OakMapBuilder<Integer, Integer>(comparator, serializer, serializer)
                 .setMinKey(Integer.MIN_VALUE)
-                .setComparator(comparator);
+                ;
     }
 
     private static int intsCompare(int int1, int int2) {

--- a/core/src/test/java/com/oath/oak/IntegerOakMap.java
+++ b/core/src/test/java/com/oath/oak/IntegerOakMap.java
@@ -45,9 +45,8 @@ public class IntegerOakMap {
     };
 
     public static OakMapBuilder<Integer, Integer> getDefaultBuilder() {
-        return new OakMapBuilder<Integer, Integer>(comparator, serializer, serializer)
-                .setMinKey(Integer.MIN_VALUE)
-                ;
+        return new OakMapBuilder<Integer, Integer>(
+            comparator, serializer, serializer, Integer.MIN_VALUE);
     }
 
     private static int intsCompare(int int1, int int2) {

--- a/core/src/test/java/com/oath/oak/IteratorModificationTest.java
+++ b/core/src/test/java/com/oath/oak/IteratorModificationTest.java
@@ -32,11 +32,10 @@ public class IteratorModificationTest {
 
     @Before
     public void init() {
-        OakMapBuilder<String, String> builder = new OakMapBuilder<String, String>()
+        OakMapBuilder<String, String> builder =
+            new OakMapBuilder<String, String>(
+                new StringComparator(), new StringSerializer(), new StringSerializer())
                 .setChunkMaxItems(100)
-                .setKeySerializer(new StringSerializer())
-                .setValueSerializer(new StringSerializer())
-                .setComparator(new StringComparator())
                 .setMinKey("");
 
         oak = builder.build();

--- a/core/src/test/java/com/oath/oak/IteratorModificationTest.java
+++ b/core/src/test/java/com/oath/oak/IteratorModificationTest.java
@@ -34,9 +34,9 @@ public class IteratorModificationTest {
     public void init() {
         OakMapBuilder<String, String> builder =
             new OakMapBuilder<String, String>(
-                new StringComparator(), new StringSerializer(), new StringSerializer())
+                new StringComparator(), new StringSerializer(), new StringSerializer(), "")
                 .setChunkMaxItems(100)
-                .setMinKey("");
+                ;
 
         oak = builder.build();
 

--- a/core/src/test/java/com/oath/oak/OakViewTests.java
+++ b/core/src/test/java/com/oath/oak/OakViewTests.java
@@ -34,9 +34,9 @@ public class OakViewTests {
     public void init() {
         OakMapBuilder<String, String> builder =
             new OakMapBuilder<String, String>(
-                new StringComparator(), new StringSerializer(), new StringSerializer())
+                new StringComparator(), new StringSerializer(), new StringSerializer(), "")
                 .setChunkMaxItems(100)
-                .setMinKey("");
+                ;
 
         oak = builder.build();
 

--- a/core/src/test/java/com/oath/oak/OakViewTests.java
+++ b/core/src/test/java/com/oath/oak/OakViewTests.java
@@ -32,11 +32,10 @@ public class OakViewTests {
 
     @Before
     public void init() {
-        OakMapBuilder<String, String> builder = new OakMapBuilder<String, String>()
+        OakMapBuilder<String, String> builder =
+            new OakMapBuilder<String, String>(
+                new StringComparator(), new StringSerializer(), new StringSerializer())
                 .setChunkMaxItems(100)
-                .setKeySerializer(new StringSerializer())
-                .setValueSerializer(new StringSerializer())
-                .setComparator(new StringComparator())
                 .setMinKey("");
 
         oak = builder.build();

--- a/core/src/test/java/com/oath/oak/ResizeValueTest.java
+++ b/core/src/test/java/com/oath/oak/ResizeValueTest.java
@@ -17,9 +17,9 @@ public class ResizeValueTest {
     public void initStuff() {
         OakMapBuilder<String, String> builder =
             new OakMapBuilder<String, String>(
-                new StringComparator(), new StringSerializer(), new StringSerializer())
+                new StringComparator(), new StringSerializer(), new StringSerializer(), "")
                 .setChunkMaxItems(100)
-                .setMinKey("");
+                ;
 
         oak = builder.build();
     }

--- a/core/src/test/java/com/oath/oak/ResizeValueTest.java
+++ b/core/src/test/java/com/oath/oak/ResizeValueTest.java
@@ -15,11 +15,10 @@ public class ResizeValueTest {
 
     @Before
     public void initStuff() {
-        OakMapBuilder<String, String> builder = new OakMapBuilder<String, String>()
+        OakMapBuilder<String, String> builder =
+            new OakMapBuilder<String, String>(
+                new StringComparator(), new StringSerializer(), new StringSerializer())
                 .setChunkMaxItems(100)
-                .setKeySerializer(new StringSerializer())
-                .setValueSerializer(new StringSerializer())
-                .setComparator(new StringComparator())
                 .setMinKey("");
 
         oak = builder.build();

--- a/core/src/test/java/com/oath/oak/UnsafeUtilsTest.java
+++ b/core/src/test/java/com/oath/oak/UnsafeUtilsTest.java
@@ -20,9 +20,8 @@ public class UnsafeUtilsTest {
 
         OakMapBuilder<IntHolder, IntHolder> builder =
             new OakMapBuilder<IntHolder, IntHolder>(
-                new UnsafeTestComparator(),new UnsafeTestSerializer(),new UnsafeTestSerializer())
-                .setMinKey(minKey)
-                ;
+                new UnsafeTestComparator(),
+                new UnsafeTestSerializer(),new UnsafeTestSerializer(), minKey);
 
         OakMap<IntHolder, IntHolder> oak = builder.build();
 

--- a/core/src/test/java/com/oath/oak/UnsafeUtilsTest.java
+++ b/core/src/test/java/com/oath/oak/UnsafeUtilsTest.java
@@ -18,11 +18,11 @@ public class UnsafeUtilsTest {
 
         IntHolder minKey = new IntHolder(0, new int[0]);
 
-        OakMapBuilder<IntHolder, IntHolder> builder = new OakMapBuilder<IntHolder, IntHolder>()
-                .setKeySerializer(new UnsafeTestSerializer())
-                .setValueSerializer(new UnsafeTestSerializer())
+        OakMapBuilder<IntHolder, IntHolder> builder =
+            new OakMapBuilder<IntHolder, IntHolder>(
+                new UnsafeTestComparator(),new UnsafeTestSerializer(),new UnsafeTestSerializer())
                 .setMinKey(minKey)
-                .setComparator(new UnsafeTestComparator());
+                ;
 
         OakMap<IntHolder, IntHolder> oak = builder.build();
 


### PR DESCRIPTION
This is a change to answer the suggestion in Issue#63 to not allow building an OakMap without non-null comparator and serializers. This in order to check for initial mistakes.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
