### PR TITLE
Fixing a bug in Descending Scan that the same keys were returned multiple times

### DIFF
--- a/core/src/main/java/com/oath/oak/Chunk.java
+++ b/core/src/main/java/com/oath/oak/Chunk.java
@@ -1185,6 +1185,8 @@ public class Chunk<K, V> {
                     if (comparator.compareSerializedKeys(tmpBBprevAnchorKey, readSecondKey(next)) > 0) {
                         stack.push(next);
                         next = getEntryFieldInt(next, OFFSET.NEXT);
+                    } else {
+                        break;
                     }
                 }
             }

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -7,6 +7,8 @@
 package com.oath.oak;
 
 
+import com.oath.oak.NativeAllocator.OakNativeMemoryAllocator;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.AbstractMap;
@@ -979,8 +981,11 @@ class InternalOakMap<K, V> {
 
     private ByteBuffer getKeyByteBuffer(long keyReference) {
         int[] keyArray = longToInts(keyReference);
-        return memoryManager.getByteBufferFromBlockID(keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> KEY_BLOCK_SHIFT,
-                keyArray[POSITION_ARRAY_INDEX], keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK);
+        return memoryManager.getByteBufferFromBlockID(
+            keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> KEY_BLOCK_SHIFT,
+                keyArray[POSITION_ARRAY_INDEX],
+            keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK,
+            OakNativeMemoryAllocator.FIRST_THREAD_BUFFER);
     }
 
     private OakRReference setKeyReference(long keyReference, OakRReference key) {

--- a/core/src/main/java/com/oath/oak/MemoryManager.java
+++ b/core/src/main/java/com/oath/oak/MemoryManager.java
@@ -1,5 +1,7 @@
 package com.oath.oak;
 
+import com.oath.oak.NativeAllocator.OakNativeMemoryAllocator;
+
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 
@@ -39,13 +41,14 @@ public interface MemoryManager extends Closeable {
     void releaseSlice(Slice s);
 
     default Slice getSliceFromBlockID(int blockID, int bufferPosition, int bufferLength) {
-        return new Slice(blockID, getByteBufferFromBlockID(blockID, bufferPosition, bufferLength));
+        return new Slice(blockID, getByteBufferFromBlockID(blockID, bufferPosition, bufferLength,
+            OakNativeMemoryAllocator.FIRST_THREAD_BUFFER));
     }
 
     /**
      * Translates the trio of blockID, position and length (a.k.a reference) into a ByteBuffer.
-     *
+     * @param numerator what is the number of the buffer requested by the same thread
      * @return the reconstructed ByteBuffer
      */
-    ByteBuffer getByteBufferFromBlockID(int blockID, int bufferPosition, int bufferLength);
+    ByteBuffer getByteBufferFromBlockID(int blockID, int bufferPosition, int bufferLength, int numerator);
 }

--- a/core/src/main/java/com/oath/oak/NativeAllocator/OakNativeMemoryAllocator.java
+++ b/core/src/main/java/com/oath/oak/NativeAllocator/OakNativeMemoryAllocator.java
@@ -39,6 +39,9 @@ public class OakNativeMemoryAllocator implements OakBlockMemoryAllocator {
     private static final int REUSE_MAX_MULTIPLIER = 2;
     public static final int INVALID_BLOCK_ID = 0;
 
+    public static final int FIRST_THREAD_BUFFER = 1;
+    public static final int SECOND_THREAD_BUFFER = 2;
+
     // mapping IDs to blocks allocated solely to this Allocator
     private final Block[] blocksArray;
     private final AtomicInteger idGenerator = new AtomicInteger(1);
@@ -228,11 +231,11 @@ public class OakNativeMemoryAllocator implements OakBlockMemoryAllocator {
 
     // When some buffer need to be read from a random block
     @Override
-    public ByteBuffer readByteBufferFromBlockID(int blockID, int bufferPosition, int bufferLength) {
+    public ByteBuffer readByteBufferFromBlockID(int blockID, int bufferPosition, int bufferLength, int numerator) {
         Block b = blocksArray[blockID];
         // The returned buffer is this thread's block buffer.
         // Therefore, a thread cannot read two slices from the same block without duplicating one of them.
-        return b.getBufferForThread(bufferPosition, bufferLength);
+        return b.getBufferForThread(bufferPosition, bufferLength, numerator);
     }
 
     // used only for testing

--- a/core/src/main/java/com/oath/oak/NoFreeMemoryManager.java
+++ b/core/src/main/java/com/oath/oak/NoFreeMemoryManager.java
@@ -46,9 +46,10 @@ public class NoFreeMemoryManager implements MemoryManager {
     }
 
     @Override
-    public ByteBuffer getByteBufferFromBlockID(int blockID, int bufferPosition, int bufferLength) {
+    public ByteBuffer getByteBufferFromBlockID(
+        int blockID, int bufferPosition, int bufferLength, int numerator) {
         return keysMemoryAllocator.readByteBufferFromBlockID(
-                blockID, bufferPosition, bufferLength);
+                blockID, bufferPosition, bufferLength, numerator);
     }
 
     public boolean isClosed() {

--- a/core/src/main/java/com/oath/oak/NovaManager.java
+++ b/core/src/main/java/com/oath/oak/NovaManager.java
@@ -68,8 +68,10 @@ public class NovaManager implements MemoryManager {
     }
 
     @Override
-    public ByteBuffer getByteBufferFromBlockID(int blockID, int bufferPosition, int bufferLength) {
-        return allocator.readByteBufferFromBlockID(blockID, bufferPosition, bufferLength);
+    public ByteBuffer getByteBufferFromBlockID(
+        int blockID, int bufferPosition, int bufferLength, int numerator) {
+        return allocator.readByteBufferFromBlockID(
+            blockID, bufferPosition, bufferLength, numerator);
     }
 
 }

--- a/core/src/main/java/com/oath/oak/OakBlockMemoryAllocator.java
+++ b/core/src/main/java/com/oath/oak/OakBlockMemoryAllocator.java
@@ -31,7 +31,8 @@ public interface OakBlockMemoryAllocator {
     long allocated();
 
     // Translates from blockID, buffer position and buffer length to ByteBuffer
-    ByteBuffer readByteBufferFromBlockID(int blockID, int bufferPosition, int bufferLength);
+    // @param numerator explains whether it needs to be first or second buffer for the same thread
+    ByteBuffer readByteBufferFromBlockID(int blockID, int bufferPosition, int bufferLength, int numerator);
 
     // Check if this Allocator was already closed
     boolean isClosed();

--- a/core/src/main/java/com/oath/oak/OakRKeyBufferImpl.java
+++ b/core/src/main/java/com/oath/oak/OakRKeyBufferImpl.java
@@ -6,6 +6,8 @@
 
 package com.oath.oak;
 
+import com.oath.oak.NativeAllocator.OakNativeMemoryAllocator;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.function.Function;
@@ -30,8 +32,11 @@ public class OakRKeyBufferImpl implements OakRBuffer {
 
     private ByteBuffer getKeyBuffer() {
         int[] keyArray = longToInts(keyReference);
-        return memoryManager.getByteBufferFromBlockID(keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> KEY_BLOCK_SHIFT, keyArray[POSITION_ARRAY_INDEX],
-                keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK);
+        return memoryManager.getByteBufferFromBlockID(
+            keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> KEY_BLOCK_SHIFT,
+            keyArray[POSITION_ARRAY_INDEX],
+                keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK,
+            OakNativeMemoryAllocator.FIRST_THREAD_BUFFER);
     }
 
     @Override

--- a/core/src/main/java/com/oath/oak/OakRReference.java
+++ b/core/src/main/java/com/oath/oak/OakRReference.java
@@ -133,6 +133,7 @@ public class OakRReference implements OakRBuffer {
         assert blockID != OakNativeMemoryAllocator.INVALID_BLOCK_ID;
         assert position != -1;
         assert length != -1;
-        return memoryManager.getByteBufferFromBlockID(blockID, position, length);
+        return memoryManager.getByteBufferFromBlockID(
+            blockID, position, length, OakNativeMemoryAllocator.FIRST_THREAD_BUFFER);
     }
 }

--- a/core/src/main/java/com/oath/oak/Slice.java
+++ b/core/src/main/java/com/oath/oak/Slice.java
@@ -6,6 +6,8 @@
 
 package com.oath.oak;
 
+import com.oath.oak.NativeAllocator.OakNativeMemoryAllocator;
+
 import java.nio.ByteBuffer;
 
 import static com.oath.oak.ValueUtilsImpl.LockStates.FREE;
@@ -25,7 +27,8 @@ public class Slice {
     }
 
     Slice(int blockID, int position, int length, MemoryManager memoryManager) {
-        this(blockID, memoryManager.getByteBufferFromBlockID(blockID, position, length));
+        this(blockID, memoryManager.getByteBufferFromBlockID(blockID, position, length,
+            OakNativeMemoryAllocator.FIRST_THREAD_BUFFER));
     }
 
     public Slice duplicate() {

--- a/core/src/test/java/com/oath/oak/SingleThreadIteratorTest.java
+++ b/core/src/test/java/com/oath/oak/SingleThreadIteratorTest.java
@@ -227,7 +227,7 @@ public class SingleThreadIteratorTest {
         }
     }
 
-    @Test
+    @Test(timeout = 100000)
     public void testRandomDescending() {
         // it is important to test different distribution of inserted keys, not only increasing
         try (OakMap<Integer, Integer> oakDesc = oak.descendingMap()) {


### PR DESCRIPTION
Added a test that failed due to existing problem. The test doesn't fail after the fix. All tests pass. Performance evaluation show no degradation. 


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
