### PR TITLE
PERF: Removing reference to block array in the memory allocator after closing

### DIFF
--- a/core/src/main/java/com/oath/oak/NativeAllocator/OakNativeMemoryAllocator.java
+++ b/core/src/main/java/com/oath/oak/NativeAllocator/OakNativeMemoryAllocator.java
@@ -204,7 +204,7 @@ public class OakNativeMemoryAllocator implements OakBlockMemoryAllocator {
             return;
         }
 
-        // Release the hold of the block array and return it the the provider.
+        // Release the hold of the block array and return it the provider.
         Block[] b = blocksArray;
         blocksArray = null;
 

--- a/core/src/main/java/com/oath/oak/NativeAllocator/OakNativeMemoryAllocator.java
+++ b/core/src/main/java/com/oath/oak/NativeAllocator/OakNativeMemoryAllocator.java
@@ -40,7 +40,7 @@ public class OakNativeMemoryAllocator implements OakBlockMemoryAllocator {
     public static final int INVALID_BLOCK_ID = 0;
 
     // mapping IDs to blocks allocated solely to this Allocator
-    private final Block[] blocksArray;
+    private Block[] blocksArray;
     private final AtomicInteger idGenerator = new AtomicInteger(1);
 
     // free list of Slices which can be reused - sorted by buffer size, then by unique hash
@@ -203,8 +203,16 @@ public class OakNativeMemoryAllocator implements OakBlockMemoryAllocator {
         if (!closed.compareAndSet(false, true)) {
             return;
         }
+
+        // Release the hold of the block array and return it the the provider.
+        Block[] b = blocksArray;
+        blocksArray = null;
+
+        // Reset "closed" to apply a memory barrier before actually returning the block.
+        closed.set(true);
+
         for (int i = 1; i <= numberOfBlocks(); i++) {
-            blocksProvider.returnBlock(blocksArray[i]);
+            blocksProvider.returnBlock(b[i]);
         }
         // no need to do anything with the free list,
         // as all free list members were residing on one of the (already released) blocks

--- a/core/src/main/java/com/oath/oak/OakRReference.java
+++ b/core/src/main/java/com/oath/oak/OakRReference.java
@@ -123,6 +123,11 @@ public class OakRReference implements OakRBuffer {
     }
 
     private ByteBuffer getTemporaryPerThreadByteBuffer() {
+        // No access is allowed once the memory manager is closed.
+        // We avoid validating this here due to performance concerns.
+        // The correctness is persevered because when the memory manager is closed,
+        // its block array is no longer reachable.
+        // Thus, a null pointer exception will be raised once we try to get the byte buffer.
         assert blockID != OakNativeMemoryAllocator.INVALID_BLOCK_ID;
         assert position != -1;
         assert length != -1;

--- a/core/src/main/java/com/oath/oak/OakRReference.java
+++ b/core/src/main/java/com/oath/oak/OakRReference.java
@@ -124,12 +124,6 @@ public class OakRReference implements OakRBuffer {
     }
 
     private ByteBuffer getTemporaryPerThreadByteBuffer() {
-        // need to check that the entire OakMap wasn't already closed with its memoryManager
-        // if memoryManager was closed, its object is still not GCed as it is pointed from here
-        // therefore it is valid to check from here
-        if (memoryManager.isClosed()) {
-            throw new ConcurrentModificationException();
-        }
         assert blockID != OakNativeMemoryAllocator.INVALID_BLOCK_ID;
         assert position != -1;
         assert length != -1;

--- a/core/src/main/java/com/oath/oak/OakRReference.java
+++ b/core/src/main/java/com/oath/oak/OakRReference.java
@@ -10,7 +10,6 @@ import com.oath.oak.NativeAllocator.OakNativeMemoryAllocator;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.ConcurrentModificationException;
 import java.util.function.Function;
 
 /*


### PR DESCRIPTION
This will prevent unwanted access to the released block which will obviate the “isclosed()” check.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
