### PR TITLE
Fix bug: getByteBuffer() returned the a buffer that is positioned at the header instead of the data

### DIFF
--- a/benchmarks/synchrobench/run.sh
+++ b/benchmarks/synchrobench/run.sh
@@ -44,9 +44,9 @@ declare -A scenarios=(
                       ["4c-get-copy"]=""
                       ["4d-95Get5Put"]="--buffer -a 0 -u 5"
                       ["4e-entrySet-ascend"]="--buffer -c"
-                      #["4e-entryStreamSet-ascend"]="--buffer -c --stream-iteration"
+                      ["4e-entryStreamSet-ascend"]="--buffer -c --stream-iteration"
                       ["4f-entrySet-descend"]="--buffer -c -a 100"
-                      #["4f-entryStreamSet-descend"]="--buffer -c -a 100 --stream-iteration"
+                      ["4f-entryStreamSet-descend"]="--buffer -c -a 100 --stream-iteration"
                      )
 
 

--- a/benchmarks/synchrobench/run.sh
+++ b/benchmarks/synchrobench/run.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 dir=`pwd`
-output=${dir}/output
+
+# Get the output path as the first parameter. Default is <pwd>/output.
+output=${1:-${dir}/output}
 java=java
 jarfile="target/oak-benchmarks-synchrobench-0.1.6-SNAPSHOT.jar"
 

--- a/core/src/main/java/com/oath/oak/OakWBufferImpl.java
+++ b/core/src/main/java/com/oath/oak/OakWBufferImpl.java
@@ -14,15 +14,15 @@ import java.nio.ByteOrder;
 public class OakWBufferImpl implements OakWBuffer {
 
     private ByteBuffer bb;
-    private final ValueUtils valueOperator;
 
     OakWBufferImpl(Slice s, ValueUtils valueOperator) {
-        this.bb = s.getByteBuffer();
-        this.valueOperator = valueOperator;
-    }
+        ByteBuffer buff = s.getByteBuffer();
+        int initPos = buff.position();
+        buff.position(initPos + valueOperator.getHeaderSize());
+        this.bb = buff.slice();
 
-    private int valuePosition() {
-        return bb.position() + valueOperator.getHeaderSize();
+        // It is important to return the original buffer to its original state.
+        buff.position(initPos);
     }
 
     @Override
@@ -32,23 +32,17 @@ public class OakWBufferImpl implements OakWBuffer {
 
     @Override
     public int capacity() {
-        return bb.remaining() - valueOperator.getHeaderSize();
+        return bb.remaining();
     }
 
     @Override
     public byte get(int index) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        return bb.get(index + valuePosition());
+        return bb.get(index);
     }
 
     @Override
     public OakWBuffer put(int index, byte b) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        bb.put(index + valuePosition(), b);
+        bb.put(index, b);
         return this;
     }
 
@@ -59,104 +53,67 @@ public class OakWBufferImpl implements OakWBuffer {
 
     @Override
     public char getChar(int index) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        return bb.getChar(index + valuePosition());
+        return bb.getChar(index);
     }
 
     @Override
     public OakWBuffer putChar(int index, char value) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        bb.putChar(index + valuePosition(), value);
+        bb.putChar(index, value);
         return this;
     }
 
     @Override
     public short getShort(int index) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        return bb.getShort(index + valuePosition());
+        return bb.getShort(index);
     }
 
     @Override
     public OakWBuffer putShort(int index, short value) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        bb.putShort(index + valuePosition(), value);
+        bb.putShort(index, value);
         return this;
     }
 
     @Override
     public int getInt(int index) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        return bb.getInt(index + valuePosition());
+        return bb.getInt(index);
     }
 
     @Override
     public OakWBuffer putInt(int index, int value) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        bb.putInt(index + valuePosition(), value);
+        bb.putInt(index, value);
         return this;
     }
 
     @Override
     public long getLong(int index) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        return bb.getLong(index + valuePosition());
+        return bb.getLong(index);
     }
 
     @Override
     public OakWBuffer putLong(int index, long value) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        bb.putLong(index + valuePosition(), value);
+        bb.putLong(index, value);
         return this;
     }
 
     @Override
     public float getFloat(int index) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        return bb.getFloat(index + valuePosition());
+        return bb.getFloat(index);
     }
 
     @Override
     public OakWBuffer putFloat(int index, float value) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        bb.putFloat(index + valuePosition(), value);
+        bb.putFloat(index, value);
         return this;
     }
 
     @Override
     public double getDouble(int index) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        return bb.getDouble(index + valuePosition());
+        return bb.getDouble(index);
     }
 
     @Override
     public OakWBuffer putDouble(int index, double value) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        bb.putDouble(index + valuePosition(), value);
+        bb.putDouble(index, value);
         return this;
     }
-
 }

--- a/core/src/main/java/com/oath/oak/OakWBufferImpl.java
+++ b/core/src/main/java/com/oath/oak/OakWBufferImpl.java
@@ -14,35 +14,42 @@ import java.nio.ByteOrder;
 public class OakWBufferImpl implements OakWBuffer {
 
     private ByteBuffer bb;
+    private int dataPos;
 
     OakWBufferImpl(Slice s, ValueUtils valueOperator) {
-        ByteBuffer buff = s.getByteBuffer();
-        int initPos = buff.position();
-        buff.position(initPos + valueOperator.getHeaderSize());
-        this.bb = buff.slice();
-
-        // It is important to return the original buffer to its original state.
-        buff.position(initPos);
+        bb = s.getByteBuffer();
+        dataPos = bb.position() + valueOperator.getHeaderSize();
     }
 
     @Override
     public ByteBuffer getByteBuffer() {
-        return bb;
+        int initPos = bb.position();
+        bb.position(dataPos);
+        ByteBuffer ret = bb.slice();
+        // It is important to return the original buffer to its original state.
+        bb.position(initPos);
+        return ret;
     }
 
     @Override
     public int capacity() {
-        return bb.remaining();
+        return bb.limit() - dataPos;
     }
 
     @Override
     public byte get(int index) {
-        return bb.get(index);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        return bb.get(dataPos + index);
     }
 
     @Override
     public OakWBuffer put(int index, byte b) {
-        bb.put(index, b);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        bb.put(dataPos + index, b);
         return this;
     }
 
@@ -53,67 +60,103 @@ public class OakWBufferImpl implements OakWBuffer {
 
     @Override
     public char getChar(int index) {
-        return bb.getChar(index);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        return bb.getChar(dataPos + index);
     }
 
     @Override
     public OakWBuffer putChar(int index, char value) {
-        bb.putChar(index, value);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        bb.putChar(dataPos + index, value);
         return this;
     }
 
     @Override
     public short getShort(int index) {
-        return bb.getShort(index);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        return bb.getShort(dataPos + index);
     }
 
     @Override
     public OakWBuffer putShort(int index, short value) {
-        bb.putShort(index, value);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        bb.putShort(dataPos + index, value);
         return this;
     }
 
     @Override
     public int getInt(int index) {
-        return bb.getInt(index);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        return bb.getInt(dataPos + index);
     }
 
     @Override
     public OakWBuffer putInt(int index, int value) {
-        bb.putInt(index, value);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        bb.putInt(dataPos + index, value);
         return this;
     }
 
     @Override
     public long getLong(int index) {
-        return bb.getLong(index);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        return bb.getLong(dataPos + index);
     }
 
     @Override
     public OakWBuffer putLong(int index, long value) {
-        bb.putLong(index, value);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        bb.putLong(dataPos + index, value);
         return this;
     }
 
     @Override
     public float getFloat(int index) {
-        return bb.getFloat(index);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        return bb.getFloat(dataPos + index);
     }
 
     @Override
     public OakWBuffer putFloat(int index, float value) {
-        bb.putFloat(index, value);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        bb.putFloat(dataPos + index, value);
         return this;
     }
 
     @Override
     public double getDouble(int index) {
-        return bb.getDouble(index);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        return bb.getDouble(dataPos + index);
     }
 
     @Override
     public OakWBuffer putDouble(int index, double value) {
-        bb.putDouble(index, value);
+        if (index < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        bb.putDouble(dataPos + index, value);
         return this;
     }
 }


### PR DESCRIPTION
Also, parameterize the benchmark output path.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
