### PR TITLE
Introduce new direct access API for OakRBuffer

### DIFF
--- a/core/src/main/java/com/oath/oak/OakRBuffer.java
+++ b/core/src/main/java/com/oath/oak/OakRBuffer.java
@@ -20,6 +20,18 @@ import java.util.function.Function;
 public interface OakRBuffer {
 
     /**
+     * @return a ByteBuffer object that is bounded to the scope of this key/value
+     */
+    @Deprecated
+    ByteBuffer getByteBuffer();
+
+    /**
+     * @return the memory address of the direct byte buffer at the relevant position
+     */
+    @Deprecated
+    long address();
+
+    /**
      * Returns this buffer's capacity.
      *
      * @return The capacity of this buffer

--- a/core/src/main/java/com/oath/oak/OakRKeyBufferImpl.java
+++ b/core/src/main/java/com/oath/oak/OakRKeyBufferImpl.java
@@ -6,6 +6,8 @@
 
 package com.oath.oak;
 
+import sun.nio.ch.DirectBuffer;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.function.Function;
@@ -31,6 +33,20 @@ public class OakRKeyBufferImpl implements OakRBuffer {
         int[] keyArray = UnsafeUtils.longToInts(keyReference);
         return memoryManager.getByteBufferFromBlockID(keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> KEY_BLOCK_SHIFT, keyArray[POSITION_ARRAY_INDEX],
                 keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK);
+    }
+
+    @Override
+    public ByteBuffer getByteBuffer() {
+        ByteBuffer buff = getKeyBuffer();
+        buff = buff.asReadOnlyBuffer();
+        buff.position(initialPosition);
+        return buff.slice();
+    }
+
+    public long address() {
+        ByteBuffer buff = getKeyBuffer();
+        long address = ((DirectBuffer) buff).address();
+        return address + initialPosition;
     }
 
     @Override

--- a/core/src/main/java/com/oath/oak/OakRReference.java
+++ b/core/src/main/java/com/oath/oak/OakRReference.java
@@ -7,6 +7,7 @@
 package com.oath.oak;
 
 import com.oath.oak.NativeAllocator.OakNativeMemoryAllocator;
+import sun.nio.ch.DirectBuffer;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -53,6 +54,20 @@ public class OakRReference implements OakRBuffer {
 
     void setLength(int length) {
         this.length = length;
+    }
+
+    @Override
+    public ByteBuffer getByteBuffer() {
+        ByteBuffer buff = getTemporaryPerThreadByteBuffer();
+        buff = buff.asReadOnlyBuffer();
+        buff.position(headerSize + position);
+        return buff.slice();
+    }
+
+    public long address() {
+        ByteBuffer buff = getTemporaryPerThreadByteBuffer();
+        long address = ((DirectBuffer) buff).address();
+        return address + headerSize + position;
     }
 
     @Override

--- a/core/src/main/java/com/oath/oak/OakRValueBufferImpl.java
+++ b/core/src/main/java/com/oath/oak/OakRValueBufferImpl.java
@@ -6,6 +6,8 @@
 
 package com.oath.oak;
 
+import sun.nio.ch.DirectBuffer;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ConcurrentModificationException;
@@ -58,8 +60,18 @@ public class OakRValueBufferImpl implements OakRBuffer {
                 valueArray[POSITION_ARRAY_INDEX], valueArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & VALUE_LENGTH_MASK);
     }
 
-    private ByteBuffer getByteBuffer() {
-        return getValueSlice().getByteBuffer();
+    @Override
+    public ByteBuffer getByteBuffer() {
+        ByteBuffer buff = getValueSlice().getByteBuffer();
+        buff = buff.asReadOnlyBuffer();
+        buff.position(valuePosition());
+        return buff.slice();
+    }
+
+    public long address() {
+        ByteBuffer buff = getValueSlice().getByteBuffer();
+        long address = ((DirectBuffer) buff).address();
+        return address + valuePosition();
     }
 
     private int valuePosition() {


### PR DESCRIPTION
The new API includes two methods:
1. getByteBuffer(): returns a ByteBuffer object that is bounded to the scope of this key/value
Used for faster repeated access to the buffer's data.

2. address(): return the memory address of the direct byte buffer at the relevant position
Used for an even faster access to the buffer's data (via Java's unsafe API) and without the need to instantiate a new ByteBuffer object.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
