### PR TITLE
Allocate min-key in InternalOakMap and Rebalancer as DirectBuffer for compatibility of implementation inside OakComparator

### DIFF
--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -62,7 +62,7 @@ class InternalOakMap<K, V> {
 
         this.comparator = oakComparator;
 
-        this.minKey = ByteBuffer.allocate(this.keySerializer.calculateSize(minKey));
+        this.minKey = ByteBuffer.allocateDirect(this.keySerializer.calculateSize(minKey));
         this.minKey.position(0);
         this.keySerializer.serialize(minKey, this.minKey);
 

--- a/core/src/main/java/com/oath/oak/Rebalancer.java
+++ b/core/src/main/java/com/oath/oak/Rebalancer.java
@@ -158,7 +158,7 @@ class Rebalancer<K, V> {
                     ByteBuffer bb = currFrozen.readKey(ei).slice();
                     int remaining = bb.remaining();
                     int position = bb.position();
-                    ByteBuffer newMinKey = ByteBuffer.allocate(remaining);
+                    ByteBuffer newMinKey = ByteBuffer.allocateDirect(remaining);
                     int myPos = newMinKey.position();
                     for (int i = 0; i < remaining; i++) {
                         newMinKey.put(myPos + i, bb.get(i + position));

--- a/core/src/main/java/com/oath/oak/Rebalancer.java
+++ b/core/src/main/java/com/oath/oak/Rebalancer.java
@@ -152,8 +152,8 @@ class Rebalancer<K, V> {
                     break;
                 } else {
                     // we have to open an new chunk
-                    // here we create a new on-heap minimal key for the second new chunk,
-                    // created by the split. The new min key is on-heap copy of the one off-heap
+                    // here we create a new minimal key buffer for the second new chunk,
+                    // created by the split. The new min key is a copy of the older one
                     // We need to use slice() method here as we want new object to be created
                     ByteBuffer bb = currFrozen.readKey(ei).slice();
                     int remaining = bb.remaining();


### PR DESCRIPTION
User implementation of OakComparator might assume the Buffer is of type DirectBuffer and try to get the buffer's address.
To make the developer's life easier, it would be better if the user can always expect a buffer of the same type, i.e., DirectBuffer.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
