### PR TITLE
Representing EntrySet to encapsulate entry management

### DIFF
--- a/core/src/main/java/com/oath/oak/Chunk.java
+++ b/core/src/main/java/com/oath/oak/Chunk.java
@@ -824,9 +824,9 @@ public class Chunk<K, V> {
                 if ((anchor - SKIP_ENTRIES_FOR_BIGGER_STACK) > 1) {
                     // try to skip more then one backward step at a time
                     // if it shows better performance
-                    anchor = anchor - SKIP_ENTRIES_FOR_BIGGER_STACK;
+                    anchor -= SKIP_ENTRIES_FOR_BIGGER_STACK;
                 } else {
-                    anchor = anchor - 1;
+                    anchor -= 1;
                 }
             }
             stack.push(anchor);

--- a/core/src/main/java/com/oath/oak/Chunk.java
+++ b/core/src/main/java/com/oath/oak/Chunk.java
@@ -199,7 +199,7 @@ public class Chunk<K, V> {
      */
     boolean finalizeDeletion(EntrySet.LookUp lookUp) {
 
-        if (entrySet.isDeleteValeFinishNeeded(lookUp)) {
+        if (!entrySet.isDeleteValeFinishNeeded(lookUp)) {
             return false;
         }
         if (!publish()) {

--- a/core/src/main/java/com/oath/oak/Chunk.java
+++ b/core/src/main/java/com/oath/oak/Chunk.java
@@ -172,7 +172,7 @@ public class Chunk<K, V> {
      * returned.
      */
     int completeLinking(EntrySet.LookUp lookUp) {
-        if (!entrySet.isDeleteValeFinishNeeded(lookUp)) {
+        if (!entrySet.isDeleteValueFinishNeeded(lookUp)) {
             // the version written in lookup is a good one!
             return lookUp.version;
         }
@@ -199,14 +199,16 @@ public class Chunk<K, V> {
      */
     boolean finalizeDeletion(EntrySet.LookUp lookUp) {
 
-        if (!entrySet.isDeleteValeFinishNeeded(lookUp)) {
+        if (!entrySet.isDeleteValueFinishNeeded(lookUp)) {
             return false;
         }
         if (!publish()) {
             return true;
         }
         try {
-            if (!entrySet.deleteValueFinish(lookUp)) return false;
+            if (!entrySet.deleteValueFinish(lookUp)) {
+                return false;
+            }
             externalSize.decrementAndGet();
             statistics.decrementAddedCount();
             return false;
@@ -648,7 +650,7 @@ public class Chunk<K, V> {
         private int next;
 
         AscendingIter() {
-            next = entrySet.getHeadNextIndex();
+            next = entrySet.getNextEntryIndex(entrySet.getHeadNextIndex());
             next = advanceNextIndex(next);
         }
 
@@ -700,7 +702,8 @@ public class Chunk<K, V> {
             from = null;
             stack = new IntStack(entrySet.getNumOfEntries());
             int sortedCnt = sortedCount.get();
-            anchor = (sortedCnt == 0 ? entrySet.getHeadNextIndex() : sortedCnt); // this is the last sorted entry
+            anchor = // this is the last sorted entry
+                (sortedCnt == 0 ? entrySet.getNextEntryIndex(entrySet.getHeadNextIndex()) : sortedCnt);
             stack.push(anchor);
             initNext();
         }

--- a/core/src/main/java/com/oath/oak/Chunk.java
+++ b/core/src/main/java/com/oath/oak/Chunk.java
@@ -219,9 +219,10 @@ public class Chunk<K, V> {
 
     /**
      * release key in slice, currently not in use, waiting for GC to be arranged
-     **/
-    void releaseKey(int entryIndex) {
-      entrySet.releaseKey(entryIndex);
+     *
+     * @param lookUp*/
+    void releaseKey(EntrySet.LookUp lookUp) {
+        entrySet.releaseKey(lookUp);
     }
 
     // Use this function to release an unreachable value reference
@@ -248,11 +249,11 @@ public class Chunk<K, V> {
     }
 
     void setKeyReference(int ei, OakRReference keyRef) {
-        entrySet.setKeyRefer(ei, keyRef);
+        entrySet.setKeyOutputRBuff(ei, keyRef);
     }
 
     boolean setValueReference(int ei, OakRReference valueRef) {
-        return entrySet.setValueRefer(ei, valueRef);
+        return entrySet.setValueOutputRBuff(ei, valueRef);
     }
 
     /**
@@ -376,7 +377,7 @@ public class Chunk<K, V> {
                 // index key. Then increase the sorted count.
                 int sortedCount = this.sortedCount.get();
                 if (sortedCount > 0) {
-                    if (ei == (sortedCount + 1)) {
+                    if (ei == (sortedCount + 1)) { // first entry has entry index 1, not 0
                         // the new entry's index is exactly after the sorted count
                         if (comparator.compareKeyAndSerializedKey(
                                 key, entrySet.readKey(sortedCount)) >= 0) {

--- a/core/src/main/java/com/oath/oak/Chunk.java
+++ b/core/src/main/java/com/oath/oak/Chunk.java
@@ -75,8 +75,7 @@ public class Chunk<K, V> {
         this.maxItems = maxItems;
         this.entrySet =
             new EntrySet<K,V>(memoryManager, maxItems, keySerializer, valueSerializer,
-                valueOperator,
-                1);
+                valueOperator);
         // if not zero, sorted count keeps the entry index of the last
         // subsequent and ordered entry in the entries array
         this.sortedCount = new AtomicInteger(0);

--- a/core/src/main/java/com/oath/oak/ChunkOld.java
+++ b/core/src/main/java/com/oath/oak/ChunkOld.java
@@ -19,6 +19,7 @@ import static com.oath.oak.ValueUtils.INVALID_VERSION;
 import static com.oath.oak.ValueUtils.ValueResult.FALSE;
 import static com.oath.oak.ValueUtils.ValueResult.TRUE;
 
+@Deprecated // to be deleted
 public class ChunkOld<K, V> {
 
     /*-------------- Constants --------------*/

--- a/core/src/main/java/com/oath/oak/ChunkOld.java
+++ b/core/src/main/java/com/oath/oak/ChunkOld.java
@@ -82,7 +82,7 @@ public class ChunkOld<K, V> {
         RELEASED
     }
 
-    static final int NONE = 0;    // an entry with NONE as its next pointer, points to a null entry
+    static final int NONE = 0;    // an entry with NONE_NEXT as its next pointer, points to a null entry
     static final int INVALID_ENTRY_INDEX = -1;
     static final long INVALID_VALUE_REFERENCE = 0;
     static final int BLOCK_ID_LENGTH_ARRAY_INDEX = 1;
@@ -120,7 +120,7 @@ public class ChunkOld<K, V> {
     // chunk can be in the following states: normal, frozen or infant(has a creator)
     private final AtomicReference<State> state;
     private AtomicReference<Rebalancer<K, V>> rebalancer;
-    private final int[] entries;    // array is initialized to 0, i.e., NONE - this is important!
+    private final int[] entries;    // array is initialized to 0, i.e., NONE_NEXT - this is important!
 
     private AtomicInteger pendingOps;
     private final AtomicInteger entryIndex;    // points to next free index of entry array
@@ -856,7 +856,7 @@ public class ChunkOld<K, V> {
      * @param srcChunk -- chunk to copy from
      * @param srcEntryIdx -- start position for copying
      * @param maxCapacity -- max number of entries "this" chunk can contain after copy
-     * @return key index of next to the last copied item, NONE if all items were copied
+     * @return key index of next to the last copied item, NONE_NEXT if all items were copied
      */
     final int copyPartNoKeys(ChunkOld<K, V> srcChunk, int srcEntryIdx, int maxCapacity) {
 
@@ -958,7 +958,7 @@ public class ChunkOld<K, V> {
         entryIndex.set(sortedEntryIndex);
         sortedCount.set(sortedEntryIndex / FIELDS);
         statistics.updateInitialSortedCount(sortedCount.get());
-        return srcEntryIdx; // if NONE then we finished copying old chunk, else we reached max in new chunk
+        return srcEntryIdx; // if NONE_NEXT then we finished copying old chunk, else we reached max in new chunk
     }
 
     /**

--- a/core/src/main/java/com/oath/oak/ChunkOld.java
+++ b/core/src/main/java/com/oath/oak/ChunkOld.java
@@ -1,0 +1,1356 @@
+/*
+ * Copyright 2018 Oath Inc.
+ * Licensed under the terms of the Apache 2.0 license.
+ * Please see LICENSE file in the project root for terms.
+ */
+
+package com.oath.oak;
+
+import sun.misc.Unsafe;
+
+import java.nio.ByteBuffer;
+import java.util.EmptyStackException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicMarkableReference;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.oath.oak.ValueUtils.INVALID_VERSION;
+import static com.oath.oak.ValueUtils.ValueResult.FALSE;
+import static com.oath.oak.ValueUtils.ValueResult.TRUE;
+
+public class ChunkOld<K, V> {
+
+    /*-------------- Constants --------------*/
+
+    /***
+     * This enum is used to access the different fields in each entry.
+     * The value associated with each entry signifies the offset of the field relative to the entry's beginning.
+     */
+    enum OFFSET {
+        /***
+         * NEXT - the next index of this entry (one integer). Must be with offset 0, otherwise, copying an entire
+         * entry should be fixed (In function {@code copyPartNoKeys}, search for "LABEL").
+         *
+         * KEY_REFERENCE - the blockID, length and position of the value pointed from this entry (size of two
+         * integers, one long).
+         *
+         * KEY_POSITION
+         *
+         * KEY_BLOCK_AND_LENGTH - similar to VALUE_BLOCK_AND_LENGTH, but using KEY_LENGTH_MASK and KEY_BLOCK_SHIFT.
+         * The length of a key is limited to 32KB.
+         *
+         * KEY_BLOCK
+         *
+         * KEY_LENGTH
+         *
+         * VALUE_REFERENCE - the blockID, length and position of the value pointed from this entry (size of two
+         * integers, one long). Equals to INVALID_VALUE_REFERENCE if no value is point.
+         *
+         * VALUE_POSITION
+         *
+         * VALUE_BLOCK_AND_LENGTH - this value holds both the blockID and the length of the value pointed by the entry.
+         * Using VALUE_LENGTH_MASK and VALUE_BLOCK_SHIFT the blockID and length can be extracted.
+         * Currently, the length of a value is limited to 8MB, and blockID is limited to 512 blocks
+         * (with the current block size of 256MB, the total memory is up to 128GB).
+         *
+         * VALUE_BLOCK
+         *
+         * VALUE_LENGTH
+         *
+         *
+         * VALUE_VERSION - as the name suggests this is the version of the value reference by VALUE_REFERENCE.
+         * It initially equals to INVALID_VERSION.
+         * If an entry with version v is removed, then this field is CASed to be -v after the value is marked
+         * off-heap and the value reference becomes INVALID_VALUE.
+         */
+        NEXT(0), KEY_REFERENCE(1), KEY_POSITION(1), KEY_BLOCK_AND_LENGTH(2), KEY_BLOCK(2), KEY_LENGTH(2),
+        VALUE_REFERENCE(3), VALUE_POSITION(3), VALUE_BLOCK_AND_LENGTH(4), VALUE_BLOCK(4), VALUE_LENGTH(4),
+        VALUE_VERSION(5);
+
+        public final int value;
+
+        OFFSET(int value) {
+            this.value = value;
+        }
+    }
+
+    enum State {
+        INFANT,
+        NORMAL,
+        FROZEN,
+        RELEASED
+    }
+
+    static final int NONE = 0;    // an entry with NONE as its next pointer, points to a null entry
+    static final int INVALID_ENTRY_INDEX = -1;
+    static final long INVALID_VALUE_REFERENCE = 0;
+    static final int BLOCK_ID_LENGTH_ARRAY_INDEX = 1;
+    static final int POSITION_ARRAY_INDEX = 0;
+    // location of the first (head) node - just a next pointer
+    private static final int HEAD_NODE = 0;
+    // index of first item in array, after head (not necessarily first in list!)
+    private static final int FIRST_ITEM = 1;
+
+    private static final int FIELDS = 6;  // # of fields in each item of entries array
+    // key block is part of key length integer, thus key length is limited to 65KB
+    static final int KEY_LENGTH_MASK = 0xffff; // 16 lower bits
+    static final int KEY_BLOCK_SHIFT = 16;
+    // Assume the length of a value is up to 8MB because there can be up to 512 blocks
+    static final int VALUE_LENGTH_MASK = 0x7fffff;
+    static final int VALUE_BLOCK_SHIFT = 23;
+
+    // used for checking if rebalance is needed
+    private static final double REBALANCE_PROB_PERC = 30;
+    private static final double SORTED_REBALANCE_RATIO = 2;
+    private static final double MAX_ENTRIES_FACTOR = 2;
+    private static final double MAX_IDLE_ENTRIES_FACTOR = 5;
+
+    // defaults
+    public static final int MAX_ITEMS_DEFAULT = 4096;
+
+    private static final Unsafe unsafe = UnsafeUtils.unsafe;
+    private final MemoryManager memoryManager;
+    ByteBuffer minKey;       // minimal key that can be put in this chunk
+    AtomicMarkableReference<ChunkOld<K, V>> next;
+    OakComparator<K> comparator;
+
+    // in split/compact process, represents parent of split (can be null!)
+    private AtomicReference<ChunkOld<K, V>> creator;
+    // chunk can be in the following states: normal, frozen or infant(has a creator)
+    private final AtomicReference<State> state;
+    private AtomicReference<Rebalancer<K, V>> rebalancer;
+    private final int[] entries;    // array is initialized to 0, i.e., NONE - this is important!
+
+    private AtomicInteger pendingOps;
+    private final AtomicInteger entryIndex;    // points to next free index of entry array
+    private final Statistics statistics;
+    // # of sorted items at entry-array's beginning (resulting from split)
+    private AtomicInteger sortedCount;
+    private final int maxItems;
+    AtomicInteger externalSize; // for updating oak's size
+    // for writing the keys into the bytebuffers
+    private final OakSerializer<K> keySerializer;
+    private final OakSerializer<V> valueSerializer;
+    private final ValueUtils valueOperator;
+
+    /*-------------- Constructors --------------*/
+
+    /**
+     * Create a new chunk
+     *
+     * @param minKey  minimal key to be placed in chunk
+     * @param creator the chunk that is responsible for this chunk creation
+     */
+    ChunkOld(ByteBuffer minKey, ChunkOld<K, V> creator, OakComparator<K> comparator, MemoryManager memoryManager,
+          int maxItems, AtomicInteger externalSize, OakSerializer<K> keySerializer, OakSerializer<V> valueSerializer,
+          ValueUtils valueOperator) {
+        this.memoryManager = memoryManager;
+        this.maxItems = maxItems;
+        this.entries = new int[maxItems * FIELDS + FIRST_ITEM];
+        this.entryIndex = new AtomicInteger(FIRST_ITEM);
+
+        this.sortedCount = new AtomicInteger(0);
+        this.minKey = minKey;
+        this.creator = new AtomicReference<>(creator);
+        if (creator == null) {
+            this.state = new AtomicReference<>(State.NORMAL);
+        } else {
+            this.state = new AtomicReference<>(State.INFANT);
+        }
+        this.next = new AtomicMarkableReference<>(null, false);
+        this.pendingOps = new AtomicInteger();
+        this.rebalancer = new AtomicReference<>(null); // to be updated on rebalance
+        this.statistics = new Statistics();
+        this.comparator = comparator;
+        this.externalSize = externalSize;
+
+        this.keySerializer = keySerializer;
+        this.valueSerializer = valueSerializer;
+        this.valueOperator = valueOperator;
+    }
+
+    static class OpData {
+        final int entryIndex;
+        final long newValueReference;
+        long oldValueReference;
+        final int oldVersion;
+        final int newVersion;
+
+        OpData(int entryIndex, long oldValueReference, long newValueReference, int oldVersion, int newVersion) {
+            this.entryIndex = entryIndex;
+            this.newValueReference = newValueReference;
+            this.oldValueReference = oldValueReference;
+            this.oldVersion = oldVersion;
+            this.newVersion = newVersion;
+        }
+    }
+
+    /*-------------- Methods --------------*/
+
+    void release() {
+        // try to change the state
+        state.compareAndSet(State.FROZEN, State.RELEASED);
+    }
+
+    /**
+     * performs CAS from 'expected' to 'value' for field at specified offset of given item in key array
+     */
+    boolean casEntriesArrayInt(int item, OFFSET offset, int expected, int value) {
+        return unsafe.compareAndSwapInt(entries,
+                Unsafe.ARRAY_INT_BASE_OFFSET + (item + offset.value) * Unsafe.ARRAY_INT_INDEX_SCALE,
+                expected, value);
+    }
+
+    boolean casEntriesArrayLong(int item, OFFSET offset, long expected, long value) {
+        return unsafe.compareAndSwapLong(entries,
+                Unsafe.ARRAY_INT_BASE_OFFSET + (item + offset.value) * Unsafe.ARRAY_INT_INDEX_SCALE,
+                expected, value);
+    }
+
+    /**
+     * write key in slice
+     **/
+    private void writeKey(K key, int ei) {
+        int keySize = keySerializer.calculateSize(key);
+        Slice s = memoryManager.allocateSlice(keySize, MemoryManager.Allocate.KEY);
+        // byteBuffer.slice() is set so it protects us from the overwrites of the serializer
+        keySerializer.serialize(key, s.getByteBuffer().slice());
+
+        setEntryFieldInt(ei, OFFSET.KEY_BLOCK, s.getBlockID());
+        setEntryFieldInt(ei, OFFSET.KEY_POSITION, s.getByteBuffer().position());
+        setEntryFieldInt(ei, OFFSET.KEY_LENGTH, keySize);
+    }
+
+    /**
+     * Reads a key given the entry index. Key is returned via reusable thread-local ByteBuffer.
+     * There is no copy just a special ByteBuffer for a single key.
+     * The thread-local ByteBuffer can be reused by different threads, however as long as
+     * a thread is invoked the ByteBuffer is related solely to this thread.
+     */
+    ByteBuffer readKey(int entryIndex) {
+        if (entryIndex == ChunkOld.NONE) {
+            return null;
+        }
+
+        long keyReference = getKeyReference(entryIndex);
+        int[] keyArray = UnsafeUtils.longToInts(keyReference);
+        int blockID = keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >> KEY_BLOCK_SHIFT;
+        int keyPosition = keyArray[POSITION_ARRAY_INDEX];
+        int length = keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK;
+
+        return memoryManager.getByteBufferFromBlockID(blockID, keyPosition, length);
+    }
+
+    /**
+     * Sets the given key reference (OakRKeyReferBufferImpl) given the entry index.
+     * There is no copy just a special ByteBuffer for a single key.
+     * The thread-local ByteBuffer can be reused by different threads, however as long as
+     * a thread is invoked the ByteBuffer is related solely to this thread.
+     */
+    void setKeyRefer(int entryIndex, OakRReference keyReferBuffer) {
+        if (entryIndex == ChunkOld.NONE) {
+            return;
+        }
+        long keyReference = getKeyReference(entryIndex);
+        int[] keyArray = UnsafeUtils.longToInts(keyReference);
+        int blockID = keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >> KEY_BLOCK_SHIFT;
+        int keyPosition = keyArray[POSITION_ARRAY_INDEX];
+        int length = keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK;
+        keyReferBuffer.setReference(blockID, keyPosition, length);
+    }
+
+    boolean setValueRefer(int entryIndex, OakRReference value) {
+        if (entryIndex == ChunkOld.NONE) {
+            return false;
+        }
+        long valueReference = getValueReference(entryIndex);
+        if (valueReference == INVALID_VALUE_REFERENCE) {
+            return false;
+        }
+        int[] valueArray = UnsafeUtils.longToInts(valueReference);
+        int blockID = valueArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >> VALUE_BLOCK_SHIFT;
+        int valuePosition = valueArray[POSITION_ARRAY_INDEX];
+        int length = valueArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & VALUE_LENGTH_MASK;
+        value.setReference(blockID, valuePosition, length);
+        return true;
+    }
+
+    /**
+     * release key in slice, currently not in use, waiting for GC to be arranged
+     **/
+    void releaseKey(int entryIndex) {
+        long keyReference = getKeyReference(entryIndex);
+        int[] keyArray = UnsafeUtils.longToInts(keyReference);
+        int blockID = keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >> KEY_BLOCK_SHIFT;
+        int keyPosition = keyArray[POSITION_ARRAY_INDEX];
+        int length = keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK;
+        Slice s = new Slice(blockID, keyPosition, length, memoryManager);
+
+        memoryManager.releaseSlice(s);
+    }
+
+    ByteBuffer readMinKey() {
+        int minEntry = getFirstItemEntryIndex();
+        return readKey(minEntry);
+    }
+
+    ByteBuffer readMaxKey() {
+        int maxEntry = getLastItemEntryIndex();
+        return readKey(maxEntry);
+    }
+
+    private int getValueVersion(int item) {
+        return getEntryFieldInt(item, OFFSET.VALUE_VERSION);
+    }
+
+    /**
+     * gets the field of specified offset for given item in entry array
+     */
+    private int getEntryFieldInt(int item, OFFSET offset) {
+        switch (offset) {
+            case KEY_LENGTH:
+                // return two low bytes of the key length index int
+                return (entries[item + offset.value] & KEY_LENGTH_MASK);
+            case KEY_BLOCK:
+                // offset must be OFFSET_KEY_BLOCK, return 2 high bytes of the int inside key length
+                // right-shift force, fill empty with zeroes
+                return (entries[item + offset.value] >>> KEY_BLOCK_SHIFT);
+            case VALUE_LENGTH:
+                return (entries[item + offset.value] & VALUE_LENGTH_MASK);
+            case VALUE_BLOCK:
+                return (entries[item + offset.value] >>> VALUE_BLOCK_SHIFT);
+            default:
+                return entries[item + offset.value];
+        }
+    }
+
+    // Atomically reads two integers of the entries array.
+    // Should be used with OFFSET.VALUE_REFERENCE and OFFSET.KEY_REFERENCE
+    private long getEntryFieldLong(int item, OFFSET offset) {
+        long arrayOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (item + offset.value) * Unsafe.ARRAY_INT_INDEX_SCALE;
+        assert arrayOffset % 8 == 0;
+        return unsafe.getLongVolatile(entries, arrayOffset);
+    }
+
+    /**
+     * * sets the field of specified offset to 'value' for given item in entry array
+     */
+    private void setEntryFieldInt(int item, OFFSET offset, int value) {
+        assert item + offset.value >= 0;
+        switch (offset) {
+            case KEY_LENGTH:
+                // OFFSET_KEY_LENGTH and OFFSET_KEY_BLOCK should be less then 16 bits long
+                // *2 in order to get read of the signed vs unsigned limits
+                assert value < Short.MAX_VALUE * 2;
+                // set two low bytes of the key block id and length index
+                entries[item + offset.value] =
+                        (entries[item + offset.value]) | (value & KEY_LENGTH_MASK);
+                return;
+            case KEY_BLOCK:
+                // OFFSET_KEY_LENGTH and OFFSET_KEY_BLOCK should be less then 16 bits long
+                // *2 in order to get read of the signed vs unsigned limits
+                assert value < Short.MAX_VALUE * 2;
+                // offset must be OFFSET_KEY_BLOCK,
+                // set 2 high bytes of the int inside OFFSET_KEY_LENGTH
+                assert value > 0; // block id can never be 0
+                entries[item + offset.value] =
+                        (entries[item + offset.value]) | (value << KEY_BLOCK_SHIFT);
+                return;
+            case VALUE_LENGTH:
+                // make sure the length is at most 2^23 and at least 0
+                assert (value & VALUE_LENGTH_MASK) == value;
+                entries[item + offset.value] =
+                        (entries[item + offset.value]) | (value & VALUE_LENGTH_MASK);
+                return;
+            case VALUE_BLOCK:
+                assert value > 0; // block id can never be 0
+                assert ((value << VALUE_BLOCK_SHIFT) >>> VALUE_BLOCK_SHIFT) == value; // value is up to 2^9
+                entries[item + offset.value] =
+                        (entries[item + offset.value]) | (value << VALUE_BLOCK_SHIFT);
+                return;
+            default:
+                entries[item + offset.value] = value;
+        }
+    }
+
+    private void setEntryFieldLong(int item, OFFSET offset, long value) {
+        long arrayOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (item + offset.value) * Unsafe.ARRAY_INT_INDEX_SCALE;
+        assert arrayOffset % 8 == 0;
+        unsafe.putLongVolatile(entries, arrayOffset, value);
+    }
+
+    Slice buildValueSlice(long valueReference) {
+        if (valueReference == INVALID_VALUE_REFERENCE) {
+            return null;
+        }
+        int[] valueArray = UnsafeUtils.longToInts(valueReference);
+        return new Slice(valueArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> VALUE_BLOCK_SHIFT,
+                valueArray[POSITION_ARRAY_INDEX], valueArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & VALUE_LENGTH_MASK,
+                memoryManager);
+    }
+
+    // Atomically reads the value reference from the entry array
+    long getValueReference(int entryIndex) {
+        return getEntryFieldLong(entryIndex, OFFSET.VALUE_REFERENCE);
+    }
+
+    /**
+     * Atomically reads both the value reference and its value. It does that by using the atomic snapshot technique
+     * (reading the version, then the reference, and finally the version again, checking that it matches the version
+     * read previously). Since a snapshot is used, the LP is when reading the value reference, if the versions match,
+     * otherwise, the operation restarts.
+     *
+     * @param entryIndex The entry of which the reference and version are read
+     * @param version    an output parameter to return the version
+     * @return the read value reference
+     */
+    long getValueReferenceAndVersion(int entryIndex, int[] version) {
+        long valueReference;
+        int v;
+        do {
+            v = getValueVersion(entryIndex);
+            valueReference = getValueReference(entryIndex);
+        } while (v != getValueVersion(entryIndex));
+        version[0] = v;
+        return valueReference;
+    }
+
+    /**
+     * This function completes the insertion of a value to Oak. When inserting a value, the value reference is CASed
+     * inside the entry and only then the version is CASed. Thus, there can be a time in which the version is
+     * INVALID_VERSION or a negative one. In this function, the version is CASed to complete the insertion.
+     * <p>
+     * The version written to entry is the version written in the off-heap memory. There is no worry of concurrent
+     * removals since these removals will have to first call this function as well, and they eventually change the
+     * version as well.
+     *
+     * @param lookUp - It holds the entry to CAS, the previously written version of this entry and the value
+     *               reference from which the correct version is read.
+     * @return a version is returned.
+     * If it is {@code INVALID_VERSION} it means that a CAS was not preformed. Otherwise, a positive version is
+     * returned, and it the version written to the entry (maybe by some other thread).
+     * <p>
+     * Note that the version in the input param {@code lookUp} is updated to be the right one if a valid version was
+     * returned.
+     */
+    int completeLinking(LookUp lookUp) {
+        int entryVersion = lookUp.version;
+        // no need to complete a thing
+        if (entryVersion > INVALID_VERSION) {
+            return entryVersion;
+        }
+        if (!publish()) {
+            return INVALID_VERSION;
+        }
+        try {
+            Slice valueSlice = buildValueSlice(lookUp.valueReference);
+            int offHeapVersion = valueOperator.getOffHeapVersion(valueSlice);
+            casEntriesArrayInt(lookUp.entryIndex, OFFSET.VALUE_VERSION, entryVersion, offHeapVersion);
+            lookUp.version = offHeapVersion;
+            return offHeapVersion;
+        } finally {
+            unpublish();
+        }
+    }
+
+    /**
+     * As written in {@code writeValueFinish(LookUp)}, when changing an entry, the value reference is CASed first and
+     * later the value version, and the same applies when removing a value. However, there is another step before
+     * changing an entry to remove a value and it is marking the value off-heap (the LP). This function is used to
+     * first CAS the value reference to {@code INVALID_VALUE_REFERENCE} and then CAS the version to be a negative one.
+     * Other threads seeing a marked value call this function before they proceed (e.g., before performing a
+     * successful {@code putIfAbsent}).
+     *
+     * @param lookUp - holds the entry to change, the old value reference to CAS out, and the current value version.
+     * @return {@code true} if a rebalance is needed
+     */
+    boolean finalizeDeletion(LookUp lookUp) {
+        int version = lookUp.version;
+        if (version <= INVALID_VERSION) {
+            return false;
+        }
+        if (!publish()) {
+            return true;
+        }
+        try {
+            casEntriesArrayLong(lookUp.entryIndex, OFFSET.VALUE_REFERENCE, lookUp.valueReference,
+                    INVALID_VALUE_REFERENCE);
+            if (!casEntriesArrayInt(lookUp.entryIndex, OFFSET.VALUE_VERSION, version, -version)) {
+                return false;
+            }
+            externalSize.decrementAndGet();
+            statistics.decrementAddedCount();
+            return false;
+        } finally {
+            unpublish();
+        }
+    }
+
+    // Atomically reads the value reference from the entry array
+    long getKeyReference(int entryIndex) {
+        return getEntryFieldLong(entryIndex, OFFSET.KEY_REFERENCE);
+    }
+
+    // Use this function to release an unreachable value reference
+    void releaseValue(long newValueReference) {
+        memoryManager.releaseSlice(buildValueSlice(newValueReference));
+    }
+
+    /**
+     * look up key
+     *
+     * @param key the key to look up
+     * @return a LookUp object describing the condition of the value associated with {@code key}.
+     * If {@code lookup == null}, there is no entry with that key in this chuck.
+     * If {@code lookup.valueReference == INVALID_VALUE}, it means that there is an entry with that key (can be
+     * reused in case
+     * of {@code put}, but there is no value attached to this key (it can happen if this entry is in the midst of
+     * being inserted, or some thread removed this key and no reblanace occurred leaving the entry in the chunk).
+     * It implies that {@code lookup.valueSlice = null}.
+     * If {@code lookup.valueSlice == null && lookup.valueReference != INVALID_VALUE} it means that the value is
+     * marked off-heap as deleted, but the connection between the entry and the value was not unlinked yet.
+     */
+    LookUp lookUp(K key) {
+        // binary search sorted part of key array to quickly find node to start search at
+        // it finds previous-to-key so start with its next
+        int curr = getEntryFieldInt(binaryFind(key), OFFSET.NEXT);
+        int cmp;
+        // iterate until end of list (or key is found)
+
+        while (curr != NONE) {
+            // compare current item's key to searched key
+            cmp = comparator.compareKeyAndSerializedKey(key, readKey(curr));
+            // if item's key is larger - we've exceeded our key
+            // it's not in chunk - no need to search further
+            if (cmp < 0) {
+                return null;
+            }
+            // if keys are equal - we've found the item
+            else if (cmp == 0) {
+                long valueReference;
+                int[] version = new int[1];
+                // Atomic snapshot of version and value reference
+                valueReference = getValueReferenceAndVersion(curr, version);
+                Slice valueSlice = buildValueSlice(valueReference);
+                if (valueSlice == null) {
+                    // There is no value associated with the given key
+                    assert valueReference == INVALID_VALUE_REFERENCE;
+                    return new LookUp(null, valueReference, curr, version[0]);
+                }
+                ValueUtils.ValueResult result = valueOperator.isValueDeleted(valueSlice, version[0]);
+                if (result == TRUE) {
+                    // There is a deleted value associated with the given key
+                    return new LookUp(null, valueReference, curr, version[0]);
+                }
+                // If result == RETRY, we ignore it, since it will be discovered later down the line as well
+                return new LookUp(valueSlice, valueReference, curr, version[0]);
+            }
+            // otherwise- proceed to next item
+            else {
+                curr = getEntryFieldInt(curr, OFFSET.NEXT);
+            }
+        }
+        return null;
+    }
+
+    static class LookUp {
+
+        /**
+         * valueSlice is used for easier access to the off-heap memory. The location pointed by it is the one
+         * referenced by valueReference.
+         * If it is {@code null} it means the value is deleted or marked as deleted but still referenced by
+         * valueReference.
+         */
+        Slice valueSlice;
+        /**
+         * valueReference is composed of 3 numbers: block ID, value position and value length. All these numbers are
+         * squashed together into a long using the VALUE masks, shifts and indices.
+         * When it equals to {@code INVALID_VALUE_REFERENCE} is means that there is no value referenced from entryIndex.
+         * This field is usually used for CAS purposes since it sits in each entry.
+         */
+        final long valueReference;
+        final int entryIndex;
+        /**
+         * This is the version of the value referenced by {@code valueReference}.
+         * If {@code valueReference == INVALID_VALUE_REFERENCE}, then:
+         * {@code version <= INVALID_VERSION} if the removal was completed.
+         * {@code version > INVALID_VERSION} if the removal was not completed.
+         * else
+         * {@code version <= INVALID_VERSION} if the insertion was not completed.
+         * {@code version > INVALID_VERSION} if the insertion was completed.
+         */
+        int version;
+
+        LookUp(Slice valueSlice, long valueReference, int entryIndex, int version) {
+            this.valueSlice = valueSlice;
+            this.valueReference = valueReference;
+            this.entryIndex = entryIndex;
+            this.version = version;
+        }
+    }
+
+
+    /**
+     * binary search for largest-entry smaller than 'key' in sorted part of key array.
+     *
+     * @return the index of the entry from which to start a linear search -
+     * if key is found, its previous entry is returned!
+     */
+    private int binaryFind(K key) {
+        int sortedCount = this.sortedCount.get();
+        // if there are no sorted keys, or the first item is already larger than key -
+        // return the head node for a regular linear search
+        if ((sortedCount == 0) || comparator.compareKeyAndSerializedKey(key, readKey(FIRST_ITEM)) <= 0) {
+            return HEAD_NODE;
+        }
+
+        // optimization: compare with last key to avoid binary search
+        if (comparator.compareKeyAndSerializedKey(key, readKey((sortedCount - 1) * FIELDS + FIRST_ITEM)) > 0) {
+            return (sortedCount - 1) * FIELDS + FIRST_ITEM;
+        }
+
+        int start = 0;
+        int end = sortedCount;
+
+        while (end - start > 1) {
+            int curr = start + (end - start) / 2;
+
+            if (comparator.compareKeyAndSerializedKey(key, readKey(curr * FIELDS + FIRST_ITEM)) <= 0) {
+                end = curr;
+            } else {
+                start = curr;
+            }
+        }
+
+        return start * FIELDS + FIRST_ITEM;
+    }
+
+    /**
+     * publish operation into thread array
+     * if CAS didn't succeed then this means that a rebalancer got here first and entry is frozen
+     *
+     * @return result of CAS
+     **/
+    boolean publish() {
+        pendingOps.incrementAndGet();
+        State currentState = state.get();
+        if (currentState == State.FROZEN || currentState == State.RELEASED) {
+            pendingOps.decrementAndGet();
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * unpublish operation from thread array
+     * if CAS didn't succeed then this means that a rebalancer did this already
+     **/
+    void unpublish() {
+        pendingOps.decrementAndGet();
+    }
+
+    int allocateEntryAndKey(K key) {
+        int ei = entryIndex.getAndAdd(FIELDS);
+        if (ei + FIELDS > entries.length) {
+            return INVALID_ENTRY_INDEX;
+        }
+
+        // key and value must be set before linking to the list so it will make sense when reached before put is done
+        // setting the value reference to DELETED_VALUE atomically
+        setEntryFieldLong(ei, OFFSET.VALUE_REFERENCE, INVALID_VALUE_REFERENCE);
+        setEntryFieldInt(ei, OFFSET.VALUE_VERSION, INVALID_VERSION);
+        writeKey(key, ei);
+        return ei;
+    }
+
+    int linkEntry(int ei, K key) {
+        int prev, curr, cmp;
+        int anchor = INVALID_ENTRY_INDEX;
+
+        while (true) {
+            // start iterating from quickly-found node (by binary search) in sorted part of order-array
+            if (anchor == INVALID_ENTRY_INDEX) {
+                anchor = binaryFind(key);
+            }
+            curr = anchor;
+
+            // iterate items until key's position is found
+            while (true) {
+                prev = curr;
+                curr = getEntryFieldInt(prev, OFFSET.NEXT);    // index of next item in list
+
+                // if no item, done searching - add to end of list
+                if (curr == NONE) {
+                    break;
+                }
+                // compare current item's key to ours
+                cmp = comparator.compareKeyAndSerializedKey(key, readKey(curr));
+
+                // if current item's key is larger, done searching - add between prev and curr
+                if (cmp < 0) {
+                    break;
+                }
+
+                // if same key, someone else managed to add the key to the linked list
+                if (cmp == 0) {
+                    return curr;
+                }
+            }
+
+            // link to list between next and previous
+            // first change this key's next to point to curr
+            setEntryFieldInt(ei, OFFSET.NEXT, curr); // no need for CAS since put is not even published yet
+            if (casEntriesArrayInt(prev, OFFSET.NEXT, curr, ei)) {
+                // Here is the single place where we do enter a new entry to the chunk, meaning
+                // there is none else simultaneously inserting the same key
+                // (we were the first to insert this key).
+                // If the new entry's index is exactly after the sorted count and
+                // the entry's key is greater or equal then to the previous (sorted count)
+                // index key. Then increase the sorted count.
+                int sortedCount = this.sortedCount.get();
+                if (sortedCount > 0) {
+                    if (ei == (sortedCount * FIELDS + 1)) {
+                        // the new entry's index is exactly after the sorted count
+                        if (comparator.compareKeyAndSerializedKey(
+                                key, readKey((sortedCount - 1) * FIELDS + FIRST_ITEM)) >= 0) {
+                            // compare with sorted count key, if inserting the "if-statement",
+                            // the sorted count key is less or equal to the key just inserted
+                            this.sortedCount.compareAndSet(sortedCount, (sortedCount + 1));
+                        }
+                    }
+                }
+                return ei;
+            }
+            // CAS didn't succeed, try again
+        }
+    }
+
+    /**
+     * write value off-heap. The lock is initialized in this function as well.
+     *
+     * @param value the value to write off-heap
+     * @return a value reference for the newly allocated slice
+     **/
+    long writeValue(V value, int[] version) {
+        // the length of the given value plus its header
+        int valueLength = valueSerializer.calculateSize(value) + valueOperator.getHeaderSize();
+        // The allocated slice is actually the thread's copy moved to point to the newly allocated slice
+        Slice slice = memoryManager.allocateSlice(valueLength, MemoryManager.Allocate.VALUE);
+
+        // initializing the header version and the lock to be free
+        valueOperator.initHeader(slice);
+        // since this is a private environment, we can only use ByteBuffer::slice, instead of ByteBuffer::duplicate
+        // and then ByteBuffer::slice
+        // This is the only place where we create a new object (for the serializer).
+        valueSerializer.serialize(value, valueOperator.getValueByteBufferNoHeaderPrivate(slice));
+        // combines the blockID with the value's length (including the header)
+        return makeReference(slice, valueLength);
+    }
+
+    static long makeReference(Slice slice, int valueLength) {
+        int valueBlockAndLength = (slice.getBlockID() << VALUE_BLOCK_SHIFT) | (valueLength & VALUE_LENGTH_MASK);
+        return UnsafeUtils.intsToLong(slice.getByteBuffer().position(), valueBlockAndLength);
+    }
+
+    int getMaxItems() {
+        return maxItems;
+    }
+
+    /**
+     * This function does the physical CAS of the value reference, which is the LP of the insertion. It then tries to
+     * complete the insertion (@see #writeValueFinish(LookUp)).
+     * This is also the only place in which the size of Oak is updated.
+     *
+     * @param opData - holds the entry to which the value reference is linked, the old and new value references and
+     *               the old and new value versions.
+     * @return {@code true} if the value reference was CASed successfully.
+     */
+    ValueUtils.ValueResult linkValue(OpData opData) {
+        if (!casEntriesArrayLong(opData.entryIndex, OFFSET.VALUE_REFERENCE, opData.oldValueReference,
+                opData.newValueReference)) {
+            return FALSE;
+        }
+        casEntriesArrayInt(opData.entryIndex, OFFSET.VALUE_VERSION, opData.oldVersion, opData.newVersion);
+        assert opData.oldValueReference == INVALID_VALUE_REFERENCE;
+        assert opData.newValueReference != INVALID_VALUE_REFERENCE;
+        statistics.incrementAddedCount();
+        externalSize.incrementAndGet();
+        return TRUE;
+    }
+
+    /**
+     * Engage the chunk to a rebalancer r.
+     *
+     * @param r -- a rebalancer to engage with
+     */
+    void engage(Rebalancer<K, V> r) {
+        rebalancer.compareAndSet(null, r);
+    }
+
+    /**
+     * Checks whether the chunk is engaged with a given rebalancer.
+     *
+     * @param r -- a rebalancer object. If r is null, verifies that the chunk is not engaged to any rebalancer
+     * @return true if the chunk is engaged with r, false otherwise
+     */
+    boolean isEngaged(Rebalancer<K, V> r) {
+        return rebalancer.get() == r;
+    }
+
+    /**
+     * Fetch a rebalancer engaged with the chunk.
+     *
+     * @return rebalancer object or null if not engaged.
+     */
+    Rebalancer<K, V> getRebalancer() {
+        return rebalancer.get();
+    }
+
+    ChunkOld<K, V> creator() {
+        return creator.get();
+    }
+
+    State state() {
+        return state.get();
+    }
+
+    private void setState(State state) {
+        this.state.set(state);
+    }
+
+    void normalize() {
+        state.compareAndSet(State.INFANT, State.NORMAL);
+        creator.set(null);
+        // using fence so other puts can continue working immediately on this chunk
+        ChunkOld.unsafe.storeFence();
+    }
+
+    final int getFirstItemEntryIndex() {
+        return getEntryFieldInt(HEAD_NODE, OFFSET.NEXT);
+    }
+
+    private int getLastItemEntryIndex() {
+        // find the last sorted entry
+        int sortedCount = this.sortedCount.get();
+        int entryIndex = sortedCount == 0 ? HEAD_NODE : (sortedCount - 1) * (FIELDS) + 1;
+        int nextEntryIndex = getEntryFieldInt(entryIndex, OFFSET.NEXT);
+        while (nextEntryIndex != ChunkOld.NONE) {
+            entryIndex = nextEntryIndex;
+            nextEntryIndex = getEntryFieldInt(entryIndex, OFFSET.NEXT);
+        }
+        return entryIndex;
+    }
+
+    /**
+     * freezes chunk so no more changes can be done to it (marks pending items as frozen)
+     */
+    void freeze() {
+        setState(State.FROZEN); // prevent new puts to this chunk
+        while (pendingOps.get() != 0) ;
+    }
+
+    /***
+     * Copies entries from srcChunk performing only entries sorting on the fly
+     * (delete entries that are removed as well).
+     * @param srcChunk -- chunk to copy from
+     * @param srcEntryIdx -- start position for copying
+     * @param maxCapacity -- max number of entries "this" chunk can contain after copy
+     * @return key index of next to the last copied item, NONE if all items were copied
+     */
+    final int copyPartNoKeys(ChunkOld<K, V> srcChunk, int srcEntryIdx, int maxCapacity) {
+
+        if (srcEntryIdx == HEAD_NODE) {
+            return NONE;
+        }
+
+        // use local variables and just set the atomic variables once at the end
+        int sortedEntryIndex = entryIndex.get();
+
+        // check that we are not beyond allowed number of entries to copy from source chunk
+        int maxIdx = maxCapacity * FIELDS + 1;
+        if (sortedEntryIndex >= maxIdx) {
+            return srcEntryIdx;
+        }
+        assert srcEntryIdx <= entries.length - FIELDS;
+
+        // set the next entry index from where we start to copy
+        if (sortedEntryIndex != FIRST_ITEM) {
+            setEntryFieldInt(sortedEntryIndex - FIELDS, OFFSET.NEXT, sortedEntryIndex);
+        } else {
+            setEntryFieldInt(HEAD_NODE, OFFSET.NEXT, FIRST_ITEM);
+        }
+
+        int entryIndexStart = srcEntryIdx;
+        int entryIndexEnd = entryIndexStart - 1;
+        int srcPrevEntryIdx = NONE;
+        boolean isFirstInInterval = true;
+
+        while (true) {
+            int[] currSrcValueVersion = new int[1];
+            long currSrcValueReference = srcChunk.getValueReferenceAndVersion(srcEntryIdx, currSrcValueVersion);
+            boolean isValueDeleted = (currSrcValueReference == INVALID_VALUE_REFERENCE) ||
+                    valueOperator.isValueDeleted(buildValueSlice(currSrcValueReference), currSrcValueVersion[0]) != FALSE;
+            int entriesToCopy = entryIndexEnd - entryIndexStart + 1;
+
+            // try to find a continuous interval to copy
+            // we cannot enlarge interval: if key is removed (value reference is INVALID_VALUE_REFERENCE) or
+            // if this chunk already has all entries to start with
+            if (!isValueDeleted && (sortedEntryIndex + entriesToCopy * FIELDS < maxIdx)) {
+                // we can enlarge the interval, if it is otherwise possible:
+                // if this is first entry in the interval (we need to copy one entry anyway) OR
+                // if (on the source chunk) current entry idx directly follows the previous entry idx
+                if (isFirstInInterval || (srcPrevEntryIdx + FIELDS == srcEntryIdx)) {
+                    entryIndexEnd++;
+                    isFirstInInterval = false;
+                    srcPrevEntryIdx = srcEntryIdx;
+                    srcEntryIdx = srcChunk.getEntryFieldInt(srcEntryIdx, OFFSET.NEXT);
+                    if (srcEntryIdx != NONE) {
+                        continue;
+                    }
+
+                }
+            }
+
+            entriesToCopy = entryIndexEnd - entryIndexStart + 1;
+            if (entriesToCopy > 0) {
+                for (int i = 0; i < entriesToCopy; ++i) {
+                    int offset = i * FIELDS;
+                    // next should point to the next item
+                    entries[sortedEntryIndex + offset + OFFSET.NEXT.value]
+                            = sortedEntryIndex + offset + FIELDS;
+
+                    // LABEL: using next as the base of the entry
+                    // copy both the key and the value references the value's version => 5 integers via array copy
+                    // the first field in an entry is next, and it is not copied since it was assign
+                    // therefore, to copy the rest of the entry we use the offset of next (which we assume is 0) and
+                    // add 1 to start the copying from the subsequent field of the entry.
+                    System.arraycopy(srcChunk.entries,  // source array
+                            entryIndexStart + offset + OFFSET.NEXT.value + 1,
+                            entries,                        // destination array
+                            sortedEntryIndex + offset + OFFSET.NEXT.value + 1, (FIELDS - 1));
+                }
+
+                sortedEntryIndex += entriesToCopy * FIELDS; // update
+            }
+
+            if (isValueDeleted) { // if now this is a removed item
+                // don't copy it, continue to next item
+                srcPrevEntryIdx = srcEntryIdx;
+                srcEntryIdx = srcChunk.getEntryFieldInt(srcEntryIdx, OFFSET.NEXT);
+            }
+
+            if (srcEntryIdx == NONE || sortedEntryIndex >= maxIdx) {
+                break; // if we are done
+            }
+
+            // reset and continue
+            entryIndexStart = srcEntryIdx;
+            entryIndexEnd = entryIndexStart - 1;
+            isFirstInInterval = true;
+
+        }
+
+        // next of last item in serial should point to null
+        int setIdx = sortedEntryIndex > FIRST_ITEM ? sortedEntryIndex - FIELDS : HEAD_NODE;
+        setEntryFieldInt(setIdx, OFFSET.NEXT, NONE);
+        // update index and counter
+        entryIndex.set(sortedEntryIndex);
+        sortedCount.set(sortedEntryIndex / FIELDS);
+        statistics.updateInitialSortedCount(sortedCount.get());
+        return srcEntryIdx; // if NONE then we finished copying old chunk, else we reached max in new chunk
+    }
+
+    /**
+     * marks this chunk's next pointer so this chunk is marked as deleted
+     *
+     * @return the next chunk pointed to once marked (will not change)
+     */
+    ChunkOld<K, V> markAndGetNext() {
+        // new chunks are ready, we mark frozen chunk's next pointer so it won't change
+        // since next pointer can be changed by other split operations we need to do this in a loop - until we succeed
+        while (true) {
+            // if chunk is marked - that is ok and its next pointer will not be changed anymore
+            // return whatever chunk is set as next
+            if (next.isMarked()) {
+                return next.getReference();
+            }
+            // otherwise try to mark it
+            else {
+                // read chunk's current next
+                ChunkOld<K, V> savedNext = next.getReference();
+
+                // try to mark next while keeping the same next chunk - using CAS
+                // if we succeeded then the next pointer we remembered is set and will not change - return it
+                if (next.compareAndSet(savedNext, savedNext, false, true)) {
+                    return savedNext;
+                }
+            }
+        }
+    }
+
+
+    boolean shouldRebalance() {
+        // perform actual check only in pre defined percentage of puts
+        if (ThreadLocalRandom.current().nextInt(100) > REBALANCE_PROB_PERC) {
+            return false;
+        }
+
+        // if another thread already runs rebalance -- skip it
+        if (!isEngaged(null)) {
+            return false;
+        }
+        int numOfEntries = entryIndex.get() / FIELDS;
+        int numOfItems = statistics.getCompactedCount();
+        int sortedCount = this.sortedCount.get();
+        // Reasons for executing a rebalance:
+        // 1. There are no sorted keys and the total number of entries is above a certain threshold.
+        // 2. There are sorted keys, but the total number of unsorted keys is too big.
+        // 3. Out of the occupied entries, there are not enough actual items.
+        return (sortedCount == 0 && numOfEntries * MAX_ENTRIES_FACTOR > maxItems) ||
+                (sortedCount > 0 && (sortedCount * SORTED_REBALANCE_RATIO) < numOfEntries) ||
+                (numOfEntries * MAX_IDLE_ENTRIES_FACTOR > maxItems && numOfItems * MAX_IDLE_ENTRIES_FACTOR < numOfEntries);
+    }
+
+    /*-------------- Iterators --------------*/
+
+    AscendingIter ascendingIter() {
+        return new AscendingIter();
+    }
+
+    AscendingIter ascendingIter(K from, boolean inclusive) {
+        return new AscendingIter(from, inclusive);
+    }
+
+    DescendingIter descendingIter() {
+        return new DescendingIter();
+    }
+
+    DescendingIter descendingIter(K from, boolean inclusive) {
+        return new DescendingIter(from, inclusive);
+    }
+
+    private int advanceNextIndex(int next) {
+        long valueReference = INVALID_VALUE_REFERENCE;
+        if (next != ChunkOld.NONE) {
+            valueReference = getEntryFieldLong(next, OFFSET.VALUE_REFERENCE);
+        }
+        while (next != ChunkOld.NONE && valueReference == INVALID_VALUE_REFERENCE) {
+            next = getEntryFieldInt(next, OFFSET.NEXT);
+            if (next != ChunkOld.NONE) {
+                valueReference = getEntryFieldLong(next, OFFSET.VALUE_REFERENCE);
+            }
+        }
+        return next;
+    }
+
+    interface ChunkIter {
+        boolean hasNext();
+
+        int next();
+    }
+
+    class AscendingIter implements ChunkIter {
+
+        private int next;
+
+        AscendingIter() {
+            next = getEntryFieldInt(HEAD_NODE, OFFSET.NEXT);
+            next = advanceNextIndex(next);
+        }
+
+        AscendingIter(K from, boolean inclusive) {
+            next = getEntryFieldInt(binaryFind(from), OFFSET.NEXT);
+
+            long valueReference = INVALID_VALUE_REFERENCE;
+            int compare = -1;
+            if (next != ChunkOld.NONE) {
+                compare = comparator.compareKeyAndSerializedKey(from, readKey(next));
+                valueReference = getEntryFieldLong(next, OFFSET.VALUE_REFERENCE);
+            }
+
+            while (next != ChunkOld.NONE && (compare > 0 || (compare >= 0 && !inclusive) || valueReference == INVALID_VALUE_REFERENCE)) {
+                next = getEntryFieldInt(next, OFFSET.NEXT);
+                if (next != ChunkOld.NONE) {
+                    valueReference = getEntryFieldLong(next, OFFSET.VALUE_REFERENCE);
+                    compare = comparator.compareKeyAndSerializedKey(from, readKey(next));
+                }
+            }
+        }
+
+        private void advance() {
+            next = getEntryFieldInt(next, OFFSET.NEXT);
+            next = advanceNextIndex(next);
+        }
+
+        @Override
+        public boolean hasNext() {
+            return next != ChunkOld.NONE;
+        }
+
+        @Override
+        public int next() {
+            int toReturn = next;
+            advance();
+            return toReturn;
+        }
+    }
+
+    class DescendingIter implements ChunkIter {
+
+        private int next;
+        private int anchor;
+        private int prevAnchor;
+        private final IntStack stack;
+        private final K from;
+        private boolean inclusive;
+
+        static final int SKIP_ENTRIES_FOR_BIGGER_STACK = 1; // 1 is the lowest possible value
+
+        DescendingIter() {
+            from = null;
+            stack = new IntStack(entries.length / FIELDS);
+            int sortedCnt = sortedCount.get();
+            anchor = sortedCnt == 0 ? HEAD_NODE : (sortedCnt - 1) * (FIELDS) + 1; // this is the last sorted entry
+            stack.push(anchor);
+            initNext();
+        }
+
+        DescendingIter(K from, boolean inclusive) {
+            this.from = from;
+            this.inclusive = inclusive;
+            stack = new IntStack(entries.length / FIELDS);
+            anchor = binaryFind(from);
+            stack.push(anchor);
+            initNext();
+        }
+
+        private void initNext() {
+            traverseLinkedList(true);
+            advance();
+        }
+
+        /**
+         * use stack to find a valid next, removed items can't be next
+         */
+        private void findNewNextInStack() {
+            if (stack.empty()) {
+                next = ChunkOld.NONE;
+                return;
+            }
+            next = stack.pop();
+            long valueReference = INVALID_VALUE_REFERENCE;
+            if (next != ChunkOld.NONE) {
+                valueReference = getEntryFieldLong(next, OFFSET.VALUE_REFERENCE);
+            }
+            while (next != ChunkOld.NONE && valueReference == INVALID_VALUE_REFERENCE) {
+                if (!stack.empty()) {
+                    next = stack.pop();
+                    if (next != ChunkOld.NONE) {
+                        valueReference = getEntryFieldLong(next, OFFSET.VALUE_REFERENCE);
+                    }
+                } else {
+                    next = ChunkOld.NONE;
+                    return;
+                }
+            }
+        }
+
+        private void pushToStack(boolean compareWithPrevAnchor) {
+            while (next != ChunkOld.NONE) {
+                if (!compareWithPrevAnchor) {
+                    stack.push(next);
+                    next = getEntryFieldInt(next, OFFSET.NEXT);
+                } else {
+                    ByteBuffer tmpBBprevAnchorKey = readKey(prevAnchor);
+                    if (next != prevAnchor /*comparator.compareSerializedKeys(tmpBBprevAnchorKey, readSecondKey(next)) > 0*/) {
+                        stack.push(next);
+                        next = getEntryFieldInt(next, OFFSET.NEXT);
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        /**
+         * fill the stack
+         * @param firstTimeInvocation
+         */
+        private void traverseLinkedList(boolean firstTimeInvocation) {
+            assert stack.size() == 1; // ancor is in the stack
+            if (prevAnchor == getEntryFieldInt(anchor, OFFSET.NEXT)) {
+                // there is no next;
+                next = ChunkOld.NONE;
+                return;
+            }
+            next = getEntryFieldInt(anchor, OFFSET.NEXT);
+            if (from == null) {
+                // if this is not the first invocation, stop when reaching previous anchor
+                pushToStack(!firstTimeInvocation);
+            } else {
+                if (firstTimeInvocation) {
+                    if (inclusive) {
+                        while (next != ChunkOld.NONE
+                            && comparator.compareKeyAndSerializedKey(from, readKey(next)) >= 0) {
+                            stack.push(next);
+                            next = getEntryFieldInt(next, OFFSET.NEXT);
+                        }
+                    } else {
+                        while (next != ChunkOld.NONE
+                            && comparator.compareKeyAndSerializedKey(from, readKey(next)) > 0) {
+                            stack.push(next);
+                            next = getEntryFieldInt(next, OFFSET.NEXT);
+                        }
+                    }
+                } else {
+                    // stop when reaching previous anchor
+                    pushToStack(true);
+                }
+            }
+        }
+
+        /**
+         * find new valid anchor
+         */
+        private void findNewAnchor() {
+            assert stack.empty();
+            prevAnchor = anchor;
+            if (anchor == HEAD_NODE) {
+                next = ChunkOld.NONE; // there is no more in this chunk
+                return;
+            } else if (anchor == FIRST_ITEM) {
+                anchor = HEAD_NODE;
+            } else {
+                if ((anchor - (FIELDS*SKIP_ENTRIES_FOR_BIGGER_STACK)) > FIRST_ITEM) {
+                    // try to skip more then one backward step at a time
+                    // shows better performance
+                    anchor = anchor - (FIELDS*SKIP_ENTRIES_FOR_BIGGER_STACK);
+                } else {
+                    anchor = anchor - FIELDS;
+                }
+            }
+            stack.push(anchor);
+        }
+
+        private void advance() {
+            while (true) {
+                findNewNextInStack();
+                if (next != ChunkOld.NONE) {
+                    return;
+                }
+                // there is no next in stack
+                if (anchor == HEAD_NODE) {
+                    // there is no next at all
+                    return;
+                }
+                findNewAnchor();
+                traverseLinkedList(false);
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return next != ChunkOld.NONE;
+        }
+
+        @Override
+        public int next() {
+            int toReturn = next;
+            advance();
+            return toReturn;
+        }
+
+    }
+
+    /**
+     * just a simple stack of int, implemented with int array
+     */
+
+    static class IntStack {
+
+        private final int[] stack;
+        private int top;
+
+        IntStack(int size) {
+            stack = new int[size];
+            top = 0;
+        }
+
+        void push(int i) {
+            if (top == stack.length) {
+                throw new ArrayIndexOutOfBoundsException();
+            }
+            stack[top] = i;
+            top++;
+        }
+
+        int pop() {
+            if (empty()) {
+                throw new EmptyStackException();
+            }
+            top--;
+            return stack[top];
+        }
+
+        boolean empty() {
+            return top == 0;
+        }
+
+        int size() {
+            return top;
+        }
+
+    }
+
+    /*-------------- Statistics --------------*/
+
+    /**
+     * This class contains information about chunk utilization.
+     */
+    static class Statistics {
+        private final AtomicInteger addedCount = new AtomicInteger(0);
+        private int initialSortedCount = 0;
+
+        /**
+         * Initial sorted count here is immutable after chunk re-balance
+         */
+        void updateInitialSortedCount(int sortedCount) {
+            this.initialSortedCount = sortedCount;
+        }
+
+        /**
+         * @return number of items chunk will contain after compaction.
+         */
+        int getCompactedCount() {
+            return initialSortedCount + getAddedCount();
+        }
+
+        /**
+         * Incremented when put a key that was removed before
+         */
+        void incrementAddedCount() {
+            addedCount.incrementAndGet();
+        }
+
+        /**
+         * Decrement when remove a key that was put before
+         */
+        void decrementAddedCount() {
+            addedCount.decrementAndGet();
+        }
+
+        int getAddedCount() {
+            return addedCount.get();
+        }
+
+    }
+
+    /**
+     * @return statistics object containing approximate utilization information.
+     */
+    Statistics getStatistics() {
+        return statistics;
+    }
+
+}

--- a/core/src/main/java/com/oath/oak/EntrySet.java
+++ b/core/src/main/java/com/oath/oak/EntrySet.java
@@ -76,11 +76,11 @@ class EntrySet<K, V> {
         }
     }
 
-    static final int NONE_NEXT = 0;    // an entry with NONE_NEXT as its next pointer, points to a null entry
     static final long   INVALID_VALUE_REFERENCE = 0;
     static final long   INVALID_KEY_REFERENCE = 0;
-    static final int    BLOCK_ID_LENGTH_ARRAY_INDEX = 1;
-    static final int    POSITION_ARRAY_INDEX = 0;
+    private static final int INVALID_ENTRY_INDEX = 0;
+    private static final int    BLOCK_ID_LENGTH_ARRAY_INDEX = 1;
+    private static final int    POSITION_ARRAY_INDEX = 0;
 
     // location of the first (head) node - just a next pointer (always same value 0)
     private final int headNextIndex;
@@ -99,7 +99,7 @@ class EntrySet<K, V> {
     private static final Unsafe unsafe = UnsafeUtils.unsafe;
     private final MemoryManager memoryManager;
 
-    private final int[] entries;    // array is initialized to 0, i.e., NONE_NEXT - this is important!
+    private final int[] entries;    // array is initialized to 0, i.e., Chunk.NONE_NEXT - this is important!
     private final int entriesCapacity; // number of entries (not ints) to be maximally held
 
     private final AtomicInteger nextFreeIndex;    // points to next free index of entry array
@@ -125,7 +125,7 @@ class EntrySet<K, V> {
         this.nextFreeIndex = new AtomicInteger(FIRST_ITEM);
         this.numOfEntries = new AtomicInteger(0);
         this.entriesCapacity = entriesCapacity;
-        this.headNextIndex   = EntrySet.NONE_NEXT;
+        this.headNextIndex   = Chunk.NONE_NEXT;
         this.keySerializer   = keySerializer;
         this.valueSerializer = valueSerializer;
         this.valOffHeapOperator = valOffHeapOperator;
@@ -396,8 +396,8 @@ class EntrySet<K, V> {
      * The method serves external EntrySet users.
      */
     int getNextEntryIndex(int ei) {
-        if (ei == EntrySet.NONE_NEXT) {
-            return EntrySet.NONE_NEXT;
+        if (ei == Chunk.NONE_NEXT) {
+            return Chunk.NONE_NEXT;
         }
         return getEntryArrayFieldInt(entryIdx2intIdx(ei), OFFSET.NEXT);
     }
@@ -578,7 +578,7 @@ class EntrySet<K, V> {
      * a thread is invoked the ByteBuffer is related solely to this thread.
      */
     ByteBuffer readKey(int ei) {
-        if (ei == EntrySet.NONE_NEXT) {
+        if (ei == INVALID_ENTRY_INDEX) {
             return null;
         }
 
@@ -596,7 +596,7 @@ class EntrySet<K, V> {
     }
 
     void setKeyRefer(int ei, OakRReference keyRef) {
-        if (ei == EntrySet.NONE_NEXT) {
+        if (ei == INVALID_ENTRY_INDEX) {
             return;
         }
         long keyReference = getKeyReference(ei);
@@ -626,7 +626,7 @@ class EntrySet<K, V> {
      * a thread is invoked on the ByteBuffer is related solely to this thread.
      */
     boolean setValueRefer(int ei, OakRReference valueRef) {
-        if (ei == EntrySet.NONE_NEXT) {
+        if (ei == INVALID_ENTRY_INDEX) {
             return false;
         }
         long valueReference = getValueReference(ei);

--- a/core/src/main/java/com/oath/oak/EntrySet.java
+++ b/core/src/main/java/com/oath/oak/EntrySet.java
@@ -268,8 +268,7 @@ class EntrySet<K, V> {
             // *2 in order to get read of the signed vs unsigned limits
             assert value < Short.MAX_VALUE * 2;
             // set two low bytes of the key block id and length index
-            entries[intFieldIdx + offset.value] =
-                (entries[intFieldIdx + offset.value]) | (value & KEY_LENGTH_MASK);
+            entries[intFieldIdx + offset.value] |= (value & KEY_LENGTH_MASK);
             return;
         case KEY_BLOCK:
             // OFFSET_KEY_LENGTH and OFFSET_KEY_BLOCK should be less then 16 bits long
@@ -278,20 +277,17 @@ class EntrySet<K, V> {
             // offset must be OFFSET_KEY_BLOCK,
             // set 2 high bytes of the int inside OFFSET_KEY_LENGTH
             assert value > 0; // block id can never be 0
-            entries[intFieldIdx + offset.value] =
-                (entries[intFieldIdx + offset.value]) | (value << KEY_BLOCK_SHIFT);
+            entries[intFieldIdx + offset.value] |= (value << KEY_BLOCK_SHIFT);
             return;
         case VALUE_LENGTH:
             // make sure the length is at most 2^23 and at least 0
             assert (value & VALUE_LENGTH_MASK) == value;
-            entries[intFieldIdx + offset.value] =
-                (entries[intFieldIdx + offset.value]) | (value & VALUE_LENGTH_MASK);
+            entries[intFieldIdx + offset.value] |= (value & VALUE_LENGTH_MASK);
             return;
         case VALUE_BLOCK:
             assert value > 0; // block id can never be 0
             assert ((value << VALUE_BLOCK_SHIFT) >>> VALUE_BLOCK_SHIFT) == value; // value is up to 2^9
-            entries[intFieldIdx + offset.value] =
-                (entries[intFieldIdx + offset.value]) | (value << VALUE_BLOCK_SHIFT);
+            entries[intFieldIdx + offset.value] |= (value << VALUE_BLOCK_SHIFT);
             return;
         default:
             entries[intFieldIdx + offset.value] = value; // used for NEXT

--- a/core/src/main/java/com/oath/oak/EntrySet.java
+++ b/core/src/main/java/com/oath/oak/EntrySet.java
@@ -83,7 +83,7 @@ class EntrySet<K, V> {
     private static final int    POSITION_ARRAY_INDEX = 0;
 
     // location of the first (head) node - just a next pointer (always same value 0)
-    private final int headNextIndex;
+    private final int headNextIndex = Chunk.NONE_NEXT;
 
     // index of first item in array, after head (not necessarily first in list!)
     private static final int HEAD_NEXT_INDEX_SIZE = 1;
@@ -116,19 +116,17 @@ class EntrySet<K, V> {
     /*----------------- Constructor -------------------*/
     /**
      * Create a new EntrySet
-     *  @param memoryManager   for off-heap accesses and updates
+     * @param memoryManager   for off-heap accesses and updates
      * @param entriesCapacity how many entries should this EntrySet keep at maximum
      * @param keySerializer   used to serialize the key when written to off-heap
-     * @param headNextIdx
      */
     EntrySet(MemoryManager memoryManager, int entriesCapacity, OakSerializer<K> keySerializer,
-        OakSerializer<V> valueSerializer, ValueUtils valOffHeapOperator, int headNextIdx) {
+        OakSerializer<V> valueSerializer, ValueUtils valOffHeapOperator) {
         this.memoryManager   = memoryManager;
         this.entries         = new int[entriesCapacity * FIELDS + HEAD_NEXT_INDEX_SIZE];
         this.nextFreeIndex = new AtomicInteger(HEAD_NEXT_INDEX_SIZE);
         this.numOfEntries = new AtomicInteger(0);
         this.entriesCapacity = entriesCapacity;
-        this.headNextIndex   = Chunk.NONE_NEXT;
         this.keySerializer   = keySerializer;
         this.valueSerializer = valueSerializer;
         this.valOffHeapOperator = valOffHeapOperator;

--- a/core/src/main/java/com/oath/oak/EntrySet.java
+++ b/core/src/main/java/com/oath/oak/EntrySet.java
@@ -1,0 +1,876 @@
+/*
+ * Copyright 2018 Oath Inc.
+ * Licensed under the terms of the Apache 2.0 license.
+ * Please see LICENSE file in the project root for terms.
+ */
+
+package com.oath.oak;
+
+import sun.misc.Unsafe;
+
+import java.nio.ByteBuffer;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+import static com.oath.oak.ValueUtils.INVALID_VERSION;
+import static com.oath.oak.ValueUtils.ValueResult.FALSE;
+import static com.oath.oak.ValueUtils.ValueResult.TRUE;
+
+/* EntrySet keeps a set of entries. Entry is reference to key and value, both located off-heap.
+** EntrySet provides access, updates and manipulation on each entry, provided its index.
+** Internal class, package visibility */
+class EntrySet<K, V> {
+
+    /*-------------- Constants --------------*/
+
+    /***
+     * This enum is used to access the different fields in each entry.
+     * The value associated with each entry signifies the offset of the field relative to the entry's beginning.
+     */
+    private enum OFFSET {
+        /***
+         * NEXT - the next index of this entry (one integer). Must be with offset 0, otherwise, copying an entire
+         * entry should be fixed (In function {@code copyPartNoKeys}, search for "LABEL").
+         *
+         * KEY_REFERENCE - the blockID, length and position of the value pointed from this entry (size of two
+         * integers, one long).
+         *
+         * KEY_POSITION
+         *
+         * KEY_BLOCK_AND_LENGTH - similar to VALUE_BLOCK_AND_LENGTH, but using KEY_LENGTH_MASK and KEY_BLOCK_SHIFT.
+         * The length of a key is limited to 32KB.
+         *
+         * KEY_BLOCK
+         *
+         * KEY_LENGTH
+         *
+         * VALUE_REFERENCE - the blockID, length and position of the value pointed from this entry (size of two
+         * integers, one long). Equals to INVALID_VALUE_REFERENCE if no value is point.
+         *
+         * VALUE_POSITION
+         *
+         * VALUE_BLOCK_AND_LENGTH - this value holds both the blockID and the length of the value pointed by the entry.
+         * Using VALUE_LENGTH_MASK and VALUE_BLOCK_SHIFT the blockID and length can be extracted.
+         * Currently, the length of a value is limited to 8MB, and blockID is limited to 512 blocks
+         * (with the current block size of 256MB, the total memory is up to 128GB).
+         *
+         * VALUE_BLOCK
+         *
+         * VALUE_LENGTH
+         *
+         *
+         * VALUE_VERSION - as the name suggests this is the version of the value reference by VALUE_REFERENCE.
+         * It initially equals to INVALID_VERSION.
+         * If an entry with version v is removed, then this field is CASed to be -v after the value is marked
+         * off-heap and the value reference becomes INVALID_VALUE.
+         */
+        NEXT(0), KEY_REFERENCE(1), KEY_POSITION(1), KEY_BLOCK_AND_LENGTH(2), KEY_BLOCK(2), KEY_LENGTH(2),
+        VALUE_REFERENCE(3), VALUE_POSITION(3), VALUE_BLOCK_AND_LENGTH(4), VALUE_BLOCK(4), VALUE_LENGTH(4),
+        VALUE_VERSION(5);
+
+        final int value;
+
+        OFFSET(int value) {
+            this.value = value;
+        }
+    }
+
+    static final int    NONE = 0;    // an entry with NONE as its next pointer, points to a null entry
+    static final int    INVALID_ENTRY_INDEX = -1;
+    static final long   INVALID_VALUE_REFERENCE = 0;
+    static final int    BLOCK_ID_LENGTH_ARRAY_INDEX = 1;
+    static final int    POSITION_ARRAY_INDEX = 0;
+
+    // location of the first (head) node - just a next pointer
+    private final int headNextIndex;
+
+    // index of first item in array, after head (not necessarily first in list!)
+    private static final int FIRST_ITEM = 1;
+
+    private static final int FIELDS = 6;  // # of fields in each item of entries array
+    // key block is part of key length integer, thus key length is limited to 65KB
+    private static final int KEY_LENGTH_MASK = 0xffff; // 16 lower bits
+    private static final int KEY_BLOCK_SHIFT = 16;
+    // Assume the length of a value is up to 8MB because there can be up to 512 blocks
+    private static final int VALUE_LENGTH_MASK = 0x7fffff;
+    private static final int VALUE_BLOCK_SHIFT = 23;
+
+    private static final Unsafe unsafe = UnsafeUtils.unsafe;
+    private final MemoryManager memoryManager;
+
+    private final int[] entries;    // array is initialized to 0, i.e., NONE - this is important!
+    private final int entriesCapacity; // number of entries (not ints) to be maximally held
+
+    private final AtomicInteger numOfEntries;    // points to next free index of entry array
+
+    // for writing the keys into the bytebuffers
+    private final OakSerializer<K> keySerializer;
+    private final OakSerializer<V> valueSerializer;
+
+    private final ValueUtils valOffHeapOperator; // is used for any value off-heap metadata access
+
+    /*----------------- Constructor -------------------*/
+    /**
+     * Create a new EntrySet
+     *  @param memoryManager   for off-heap accesses and updates
+     * @param entriesCapacity how many entries should this EntrySet keep at maximum
+     * @param keySerializer   used to serialize the key when written to off-heap
+     * @param headNextIdx
+     */
+    EntrySet(MemoryManager memoryManager, int entriesCapacity, OakSerializer<K> keySerializer,
+        OakSerializer<V> valueSerializer, ValueUtils valOffHeapOperator, int headNextIdx) {
+        this.memoryManager   = memoryManager;
+        this.entries         = new int[entriesCapacity * FIELDS + FIRST_ITEM];
+        this.numOfEntries = new AtomicInteger(FIRST_ITEM);
+        this.entriesCapacity = entriesCapacity;
+        this.headNextIndex   = headNextIdx;
+        this.keySerializer   = keySerializer;
+        this.valueSerializer = valueSerializer;
+        this.valOffHeapOperator = valOffHeapOperator;
+    }
+
+    /* OpData is a class that encapsulates the EntrySet's information, from when value write started
+    * and until value write was committed. It should not be used by other classes, just transferred
+    * between writeValueStart (return parameter) to writeValueCommit (input parameter)
+    * TODO: probably to merge with LookUp and create some operation context class */
+    static class OpData {
+        final int entryIndex;
+        final long newValueReference;
+        long oldValueReference;
+        final int oldVersion;
+        final int newVersion;
+
+        OpData(int entryIndex, long oldValueReference, long newValueReference, int oldVersion, int newVersion) {
+            this.entryIndex = entryIndex;
+            this.newValueReference = newValueReference;
+            this.oldValueReference = oldValueReference;
+            this.oldVersion = oldVersion;
+            this.newVersion = newVersion;
+        }
+    }
+
+    /* LookUp is a class that encapsulates the EntrySet's information, from when entry (key) was
+     * (or wasn't) found and until the operation was completed.
+     * It should not be used by other classes, just transferred.
+     * TODO: probably to merge with OpData and create some single operation context class */
+    static class LookUp {
+        /**
+         * valueSlice is used for easier access to the off-heap memory. The location pointed by it is the one
+         * referenced by valueReference.
+         * If it is {@code null} it means the value is deleted or marked as deleted but still referenced by
+         * valueReference.
+         */
+        Slice valueSlice;
+        /**
+         * valueReference is composed of 3 numbers: block ID, value position and value length. All these numbers are
+         * squashed together into a long using the VALUE masks, shifts and indices.
+         * When it equals to {@code INVALID_VALUE_REFERENCE} is means that there is no value referenced from entryIndex.
+         * This field is usually used for CAS purposes since it sits in each entry.
+         */
+        final long valueReference;
+        final int entryIndex;
+        /**
+         * This is the version of the value referenced by {@code valueReference}.
+         * If {@code valueReference == INVALID_VALUE_REFERENCE}, then:
+         * {@code version <= INVALID_VERSION} if the removal was completed.
+         * {@code version > INVALID_VERSION} if the removal was not completed.
+         * else
+         * {@code version <= INVALID_VERSION} if the insertion was not completed.
+         * {@code version > INVALID_VERSION} if the insertion was completed.
+         */
+        int version;
+
+        LookUp(Slice valueSlice, long valueReference, int entryIndex, int version) {
+            this.valueSlice = valueSlice;
+            this.valueReference = valueReference;
+            this.entryIndex = entryIndex;
+            this.version = version;
+        }
+    }
+
+
+    /********************************************************************************************/
+    /*---------------- Methods for setting and getting specific entry's field ------------------*/
+    // we use term intIdx for the integer's index inside the entries array (referred as a set of integers),
+    // we use term entryIdx for the index of entry array (referred as a set of entries)
+
+    private int entryIdx2intIdx(int entryIdx) {
+        return (entryIdx * FIELDS) + FIRST_ITEM;
+    }
+
+    /**
+     * getEntryArrayFieldInt gets the integer field of entry at specified offset for given
+     * start of the entry index in the entry array.
+     * The field is read atomically as it is a machine word, however the concurrency of the
+     * mostly updated value is not ensured as no memory fence is issued.
+     */
+    private int getEntryArrayFieldInt(int intFieldIdx, OFFSET offset) {
+        switch (offset) {
+        case KEY_LENGTH:
+            // return two low bytes of the key length index int
+            return (entries[intFieldIdx + offset.value] & KEY_LENGTH_MASK);
+        case KEY_BLOCK:
+            // offset must be OFFSET_KEY_BLOCK, return 2 high bytes of the int inside key length
+            // right-shift force, fill empty with zeroes
+            return (entries[intFieldIdx + offset.value] >>> KEY_BLOCK_SHIFT);
+        case VALUE_LENGTH:
+            return (entries[intFieldIdx + offset.value] & VALUE_LENGTH_MASK);
+        case VALUE_BLOCK:
+            return (entries[intFieldIdx + offset.value] >>> VALUE_BLOCK_SHIFT);
+        default:
+            return entries[intFieldIdx + offset.value];
+        }
+    }
+
+    /**
+     * getEntryArrayFieldLong atomically reads two integers field of the entries array.
+     * Should be used with OFFSET.VALUE_REFERENCE and OFFSET.KEY_REFERENCE
+     * The concurrency is ensured due to memory fence as part of "volatile"
+     */
+    private long getEntryArrayFieldLong(int intStartFieldIdx, OFFSET offset) {
+        long arrayOffset =
+            Unsafe.ARRAY_INT_BASE_OFFSET + (intStartFieldIdx + offset.value) * Unsafe.ARRAY_INT_INDEX_SCALE;
+        assert arrayOffset % 8 == 0;
+        return unsafe.getLongVolatile(entries, arrayOffset);
+    }
+
+    /**
+     * setEntryFieldInt sets the integer field of specified offset to 'value'
+     * for given integer index in the entry array
+     */
+    private void setEntryFieldInt(int intFieldIdx, OFFSET offset, int value) {
+        assert intFieldIdx + offset.value >= 0;
+        switch (offset) {
+        case KEY_LENGTH:
+            // OFFSET_KEY_LENGTH and OFFSET_KEY_BLOCK should be less then 16 bits long
+            // *2 in order to get read of the signed vs unsigned limits
+            assert value < Short.MAX_VALUE * 2;
+            // set two low bytes of the key block id and length index
+            entries[intFieldIdx + offset.value] =
+                (entries[intFieldIdx + offset.value]) | (value & KEY_LENGTH_MASK);
+            return;
+        case KEY_BLOCK:
+            // OFFSET_KEY_LENGTH and OFFSET_KEY_BLOCK should be less then 16 bits long
+            // *2 in order to get read of the signed vs unsigned limits
+            assert value < Short.MAX_VALUE * 2;
+            // offset must be OFFSET_KEY_BLOCK,
+            // set 2 high bytes of the int inside OFFSET_KEY_LENGTH
+            assert value > 0; // block id can never be 0
+            entries[intFieldIdx + offset.value] =
+                (entries[intFieldIdx + offset.value]) | (value << KEY_BLOCK_SHIFT);
+            return;
+        case VALUE_LENGTH:
+            // make sure the length is at most 2^23 and at least 0
+            assert (value & VALUE_LENGTH_MASK) == value;
+            entries[intFieldIdx + offset.value] =
+                (entries[intFieldIdx + offset.value]) | (value & VALUE_LENGTH_MASK);
+            return;
+        case VALUE_BLOCK:
+            assert value > 0; // block id can never be 0
+            assert ((value << VALUE_BLOCK_SHIFT) >>> VALUE_BLOCK_SHIFT) == value; // value is up to 2^9
+            entries[intFieldIdx + offset.value] =
+                (entries[intFieldIdx + offset.value]) | (value << VALUE_BLOCK_SHIFT);
+            return;
+        default:
+            entries[intFieldIdx + offset.value] = value;
+        }
+    }
+
+    /**
+     * setEntryFieldInt sets the two integers field of specified offset to 'value'
+     * for given integer index in the entry array
+     */
+    private void setEntryFieldLong(int item, OFFSET offset, long value) {
+        long arrayOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (item + offset.value) * Unsafe.ARRAY_INT_INDEX_SCALE;
+        assert arrayOffset % 8 == 0;
+        unsafe.putLongVolatile(entries, arrayOffset, value);
+    }
+
+    /**
+     * casEntriesArrayInt performs CAS of given integer field of the entries ints array,
+     * that should be associated with some field of some entry.
+     * CAS from 'expectedIntValue' to 'newIntValue' for field at specified offset
+     * of given int-field in the entries array
+     */
+    private boolean casEntriesArrayInt(
+        int intFieldIdx, OFFSET offset, int expectedIntValue, int newIntValue) {
+        return unsafe.compareAndSwapInt(entries,
+                Unsafe.ARRAY_INT_BASE_OFFSET + (intFieldIdx + offset.value) * Unsafe.ARRAY_INT_INDEX_SCALE,
+                expectedIntValue, newIntValue);
+    }
+
+    /**
+     * casEntriesArrayLong performs CAS of given two integers field of the entries ints array,
+     * that should be associated with some 2 consecutive integer fields of some entry.
+     * CAS from 'expectedLongValue' to 'newLongValue' for field at specified offset
+     * of given int-field in the entries array
+     */
+    private boolean casEntriesArrayLong(
+        int intStartFieldIdx, OFFSET offset, long expectedLongValue, long newLongValue) {
+        return unsafe.compareAndSwapLong(entries,
+                Unsafe.ARRAY_INT_BASE_OFFSET + (intStartFieldIdx + offset.value) * Unsafe.ARRAY_INT_INDEX_SCALE,
+                expectedLongValue, newLongValue);
+    }
+
+    /********************************************************************************************/
+    /*--------------- Methods for setting and getting specific key and/or value ----------------*/
+    // key or value references are the triple <blockID, position, length> encapsulated in long
+    // whenever version is needed it is an additional integer
+
+    /**
+     * Atomically reads the value version from the entry (given by entry index "ei")
+     * synchronisation with reading the value reference is not ensured in this method
+     * */
+    private int getValueVersion(int ei) {
+        return getEntryArrayFieldInt(entryIdx2intIdx(ei), OFFSET.VALUE_VERSION);
+    }
+
+    /**
+     * Atomically reads the value reference from the entry (given by entry index "ei")
+     * synchronisation with reading the value version is not ensured in this method
+     * */
+    private long getValueReference(int ei) {
+        return getEntryArrayFieldLong(entryIdx2intIdx(ei), OFFSET.VALUE_REFERENCE);
+    }
+
+    /**
+     * Atomically reads both the value reference and its value (comparing the version).
+     * It does that by using the atomic snapshot technique (reading the version, then the reference,
+     * and finally the version again, checking that it matches the version read previously).
+     * Since a snapshot is used, the LP is when reading the value reference, if the versions match,
+     * otherwise, the operation restarts.
+     *
+     * @param ei The entry of which the reference and version are read
+     * @param version    an output parameter to return the version
+     * @return the read value reference
+     */
+    private long getValueReferenceAndVersion(int ei, int[] version) {
+        long valueReference;
+        int v;
+        do {
+            v = getValueVersion(ei);
+            valueReference = getValueReference(ei);
+        } while (v != getValueVersion(ei));
+        version[0] = v;
+        return valueReference;
+    }
+
+    /**
+     * Atomically reads the key reference from the entry (given by entry index "ei")
+     */
+    private long getKeyReference(int ei) {
+        return getEntryArrayFieldLong(entryIdx2intIdx(ei), OFFSET.KEY_REFERENCE);
+    }
+
+    /**
+     * Atomically reads the key reference from the entry (given by entry index "ei")
+     * and assigns blockID, position and length into given int array
+     */
+    private int[] getKeyReference2IntArray(int ei) {
+        long keyReference = getKeyReference(ei);
+        int[] answer = new int[3];
+        int[] keyArray = UnsafeUtils.longToInts(keyReference);
+        answer[0] = getKeyBlockIDFromIntArray(keyArray);   // key's BlockID
+        answer[1] = getPositionFromIntArray(keyArray);  // key's position
+        answer[2] = getKeyLengthFromIntArray(keyArray);  // key's length
+        return answer;
+    }
+
+    /********************************************************************************************/
+    /*------------- Methods for managing next entry indexes (package visibility) ---------------*/
+
+    /**
+     * getNextEntryIndex returns the next entry index (of the entry given by entry index "ei")
+     * The method serves external EntrySet users.
+     */
+    int getNextEntryIndex(int ei) {
+        if (ei == headNextIndex) { // head index is just one field therefore translated differently
+            return getEntryArrayFieldInt(headNextIndex, OFFSET.NEXT);
+        }
+        return getEntryArrayFieldInt(entryIdx2intIdx(ei), OFFSET.NEXT);
+    }
+
+    /**
+     * getHeadEntryIndex returns the head entry index
+     * The method serves external EntrySet users.
+     */
+    int getHeadNextIndex() {
+        return headNextIndex;
+    }
+
+    /**
+     * setNextEntryIndex sets the next entry index (of the entry given by entry index "ei")
+     * to be the "next". Input parameter "next" must be a valid entry index.
+     * The method serves external EntrySet users.
+     */
+    void setNextEntryIndex(int ei, int next) {
+         setEntryFieldInt(ei, OFFSET.NEXT, next);
+    }
+
+    /**
+     * casNextEntryIndex CAS the next entry index (of the entry given by entry index "ei") to be the
+     * "nextNew" only if it was "nextOld". Input parameter "nextNew" must be a valid entry index.
+     * The method serves external EntrySet users.
+     */
+    boolean casNextEntryIndex(int ei, int nextOld, int nextNew) {
+        return casEntriesArrayInt(ei, OFFSET.NEXT, nextOld, nextNew);
+    }
+
+    /********************************************************************************************/
+    /*--------------- Methods for helping managing off-heap references ----------------*/
+    // key or value references are the triple <blockID, position, length> encapsulated in long
+    // here we translate them (back and forth) to Slice or integers
+    // TODO: not directly related to EntrySet consider making static or moving to some utils
+
+    /**
+     * buildValueSlice builds a slice given value reference
+     */
+    private Slice buildValueSlice(long valueReference) {
+        if (valueReference == INVALID_VALUE_REFERENCE) {
+            return null;
+        }
+        int[] valueArray = UnsafeUtils.longToInts(valueReference);
+        return new Slice(
+            getValueBlockIDFromIntArray(valueArray),
+            getPositionFromIntArray(valueArray),
+            getValueLengthFromIntArray(valueArray),
+            memoryManager);
+    }
+
+    /**
+     * buildValueReference builds a long reference given a slice
+     */
+    private long buildValueReference(Slice slice, int valueLength) {
+        int valueBlockAndLength = (slice.getBlockID() << VALUE_BLOCK_SHIFT) | (valueLength & VALUE_LENGTH_MASK);
+        return UnsafeUtils.intsToLong(slice.getByteBuffer().position(), valueBlockAndLength);
+    }
+
+    /********************************************************************************************/
+    /*--------------- Methods for helping managing off-heap references ----------------*/
+    // key or value references are the triple <blockID, position, length> encapsulated in long
+
+    /**
+     * getKeyBlockIDFromIntArray extracts keys BlockID from the translation of the key reference (long)
+     * into array of two integers. This is done in order to avoid more int[] objects.
+     *
+     * Always use >>> (unsigned right shift) operator. It always fills 0 irrespective
+     * of the sign of the number.
+     */
+    private int getKeyBlockIDFromIntArray(int[] long2IntTranslated) {
+        return long2IntTranslated[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> KEY_BLOCK_SHIFT;
+    }
+
+    /**
+     * getValueBlockIDFromIntArray extracts value BlockID from the translation of the value reference (long)
+     * into array of two integers. This is done in order to avoid more int[] objects.
+     *
+     * Always use >>> (unsigned right shift) operator. It always fills 0 irrespective
+     * of the sign of the number.
+     */
+    private int getValueBlockIDFromIntArray(int[] long2IntTranslated) {
+        return long2IntTranslated[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> VALUE_BLOCK_SHIFT;
+    }
+
+    /**
+     * getPositionFromIntArray extracts in Block position from the translation of the off-heap
+     * reference (long) into array of two integers. This is done in order to limit int[] objects.
+     */
+    private int getPositionFromIntArray(int[] long2IntTranslated) {
+        return long2IntTranslated[POSITION_ARRAY_INDEX];
+    }
+
+    /**
+     * getKeyLengthFromIntArray extracts keys length from the translation of the key reference (long)
+     * into array of two integers. This is done in order to avoid more int[] objects.
+     */
+    private int getKeyLengthFromIntArray(int[] long2IntTranslated) {
+        return long2IntTranslated[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK;
+    }
+
+    /**
+     * getValueLengthFromIntArray extracts value length from the translation of the value reference (long)
+     * into array of two integers. This is done in order to avoid more int[] objects.
+     */
+    private int getValueLengthFromIntArray(int[] long2IntTranslated) {
+        return long2IntTranslated[BLOCK_ID_LENGTH_ARRAY_INDEX] & VALUE_LENGTH_MASK;
+    }
+
+    /********************************************************************************************/
+    /*-------------- Methods for managing keys and values of a specific entry' -----------------*/
+    // Memory Manager interface is via Slice, although Slices are not key/value containers in the
+    // EntrySet. MM allocates/releases Slices
+
+    /**
+     * buildLookUp builds a LookUp from an entry given by entry index "ei",
+     * so this entry can be referred to later
+     *
+     * If the entry itself or off-heap value is deleted the returned LookUp has null as a Slice
+     */
+    LookUp buildLookUp(int ei) {
+        long valueReference;
+        int[] version = new int[1]; // the array of size 1 in order to get output inside it
+        // Atomic snapshot of version and value reference
+        valueReference = getValueReferenceAndVersion(ei, version);
+
+        Slice valueSlice = buildValueSlice(valueReference);
+        if (valueSlice == null) {
+            // There is no value associated with the given key
+            assert valueReference == INVALID_VALUE_REFERENCE;
+            return new LookUp(null, valueReference, ei, version[0]);
+        }
+        ValueUtils.ValueResult result = valOffHeapOperator.isValueDeleted(valueSlice, version[0]);
+        if (result == TRUE) {
+            // There is a deleted value associated with the given key
+            return new LookUp(null, valueReference, ei, version[0]);
+        }
+        // If result == RETRY, we ignore it, since it will be discovered later down the line as well
+        return new LookUp(valueSlice, valueReference, ei, version[0]);
+    }
+
+    /**
+     * writeKey writes given key object "key" (to off-heap) as a serialized key, referenced by entry
+     * at the entries index "ei"
+     **/
+    private void writeKey(K key, int ei) {
+        int keySize = keySerializer.calculateSize(key);
+        int intIdx = entryIdx2intIdx(ei);
+        Slice s = memoryManager.allocateSlice(keySize, MemoryManager.Allocate.KEY);
+        // byteBuffer.slice() is set so it protects us from the overwrites of the serializer
+        // TODO: better serializer need to be given OakWBuffer and not ByteBuffer
+        keySerializer.serialize(key, s.getByteBuffer().slice());
+
+        setEntryFieldInt(intIdx, OFFSET.KEY_BLOCK, s.getBlockID());
+        setEntryFieldInt(intIdx, OFFSET.KEY_POSITION, s.getByteBuffer().position());
+        setEntryFieldInt(intIdx, OFFSET.KEY_LENGTH, keySize);
+    }
+
+    /**
+     * readKey reads a key from entry at the given entry index (from off-heap).
+     * Key is returned via reusable thread-local ByteBuffer.
+     * There is no copy just a special ByteBuffer for a single key.
+     * The thread-local ByteBuffer can be reused by different threads, however as long as
+     * a thread is invoked the ByteBuffer is related solely to this thread.
+     */
+    ByteBuffer readKey(int ei) {
+        if (ei == EntrySet.NONE) {
+            return null;
+        }
+
+        long keyReference = getKeyReference(ei);
+        int[] keyArray = UnsafeUtils.longToInts(keyReference);
+        int blockID = getKeyBlockIDFromIntArray(keyArray);
+        int keyPosition = getPositionFromIntArray(keyArray);
+        int length = getKeyLengthFromIntArray(keyArray);
+
+        return memoryManager.getByteBufferFromBlockID(blockID, keyPosition, length);
+    }
+
+    /**
+     * Sets the given key reference (OakRReference) given the entry index.
+     * There is no copy just a special ByteBuffer for a single key.
+     * The thread-local ByteBuffer can be reused by different threads, however as long as
+     * a thread is invoked the ByteBuffer is related solely to this thread.
+     */
+    void setKeyRefer(int ei, OakRReference keyRef) {
+        if (ei == EntrySet.NONE) {
+            return;
+        }
+        long keyReference = getKeyReference(ei);
+        int[] keyArray = UnsafeUtils.longToInts(keyReference);
+        int blockID = getKeyBlockIDFromIntArray(keyArray);
+        int keyPosition = getPositionFromIntArray(keyArray);
+        int length = getKeyLengthFromIntArray(keyArray);
+
+        keyRef.setReference(blockID, keyPosition, length);
+    }
+
+    /**
+     * Sets the given value reference (OakRReference) given the entry index.
+     * Returns false if: (1)there is no such entry or (2)entry has no value set
+     * Returns true otherwise
+     * a thread is invoked on the ByteBuffer is related solely to this thread.
+     */
+    boolean setValueRefer(int ei, OakRReference valueRef) {
+        if (ei == EntrySet.NONE) {
+            return false;
+        }
+        long valueReference = getValueReference(ei);
+        if (valueReference == INVALID_VALUE_REFERENCE) {
+            return false;
+        }
+        int[] valueArray = UnsafeUtils.longToInts(valueReference);
+        int blockID = getValueBlockIDFromIntArray(valueArray);
+        int valuePosition = getPositionFromIntArray(valueArray);
+        int length = getValueLengthFromIntArray(valueArray);
+
+        valueRef.setReference(blockID, valuePosition, length);
+        return true;
+    }
+
+    /**
+     * releaseKey releases key in slice, currently not in use, waiting for GC to be arranged
+     **/
+    void releaseKey(int ei) {
+        long keyReference = getKeyReference(ei);
+        int[] keyArray = UnsafeUtils.longToInts(keyReference);
+        int blockID = getKeyBlockIDFromIntArray(keyArray);
+        int keyPosition = getPositionFromIntArray(keyArray);
+        int length = getKeyLengthFromIntArray(keyArray);
+
+        Slice s = new Slice(blockID, keyPosition, length, memoryManager);
+        memoryManager.releaseSlice(s);
+    }
+
+    /**
+     * releaseValue releases value in slice, currently the method is used only to release an
+     * unreachable value reference, the one that was not yet attached to an entry!
+     * The method is part of EntrySet, because it cares also
+     * for writing the value before attaching it to an entry writeValueStart/writeValueCommit
+     **/
+    void releaseValue(long newValueReference) {
+        memoryManager.releaseSlice(buildValueSlice(newValueReference));
+    }
+
+    /**
+     * writeValueStart writes value off-heap. Supposed to be for entry index "ei",
+     * but this entry metadata is not updated in this method. This is an intermediate step in
+     * the process of inserting key-value pair, it will be finished with writeValueCommit.
+     * The off-heap header is initialized in this function as well.
+     *
+     * @param lookUp the structure that follows the operation since the key being found.
+     *               Needed here for the entry index (of the entry to be updated
+     *               when insertion of this key-value pair will be committed) and for the old version.
+     * @param value the value to write off-heap
+     * @return OpData to be used later in the writeValueCommit
+     **/
+    OpData writeValueStart(LookUp lookUp, V value) {
+        // the length of the given value plus its header
+        int valueLength = valueSerializer.calculateSize(value) + valOffHeapOperator.getHeaderSize();
+
+        // The allocated slice is actually the thread's ByteBuffer moved to point to the newly
+        // allocated slice. Version in time of allocation is set as part of the slice data.
+        Slice slice = memoryManager.allocateSlice(valueLength, MemoryManager.Allocate.VALUE);
+
+        // initializing the off-heap header (version and the lock to be free)
+        valOffHeapOperator.initHeader(slice);
+
+        // since this is a private environment, we can only use ByteBuffer::slice, instead of ByteBuffer::duplicate
+        // and then ByteBuffer::slice
+        // To be safe we create a new ByteBuffer object (for the serializer).
+        valueSerializer.serialize(value, valOffHeapOperator.getValueByteBufferNoHeaderPrivate(slice));
+
+        // combines the blockID with the value's length (including the header)
+        long valueReference = buildValueReference(slice, valueLength);
+
+        return new OpData(lookUp.entryIndex, INVALID_VALUE_REFERENCE, valueReference, lookUp.version,
+            slice.getVersion());
+    }
+
+    /**
+     * writeValueCommit does the physical CAS of the value reference, which is the Linearization
+     * Point of the insertion. It then tries to complete the insertion by CASing the value's version
+     * if was not yet assigned (@see #writeValueFinish(LookUp)).
+     *
+     * @param opData - holds the entry to which the value reference is linked, the old and new value
+     *                references and the old and new value versions.
+     * @return {@code true} if the value reference was CASed successfully.
+     */
+    ValueUtils.ValueResult writeValueCommit(OpData opData) {
+
+        assert opData.oldValueReference == INVALID_VALUE_REFERENCE;
+        assert opData.newValueReference != INVALID_VALUE_REFERENCE;
+
+        if (!casEntriesArrayLong(opData.entryIndex, OFFSET.VALUE_REFERENCE, opData.oldValueReference,
+            opData.newValueReference)) {
+            return FALSE;
+        }
+        casEntriesArrayInt(opData.entryIndex, OFFSET.VALUE_VERSION, opData.oldVersion, opData.newVersion);
+
+        return TRUE;
+    }
+
+    /**
+     * getNumOfEntries returns the number of entries allocated for this EntrySet.
+     * Because numOfEntries is used as an array index it is not decreased upon deletions.
+     * Anyway such entry can not be reused with arbitrary key (in current implementation)
+     */
+    int getNumOfEntries() {
+        return numOfEntries.get();
+    }
+
+    /**
+     * isDeleteValeFinishNeeded checks whether the version in the given lookUp is negative,
+     * which means deleted. We can not proceed on entry with negative version,
+     * it is first needs to be changed to invalid, then any other value reference (with version)
+     * can be assigned to this entry (same key).
+     */
+    boolean isDeleteValeFinishNeeded(LookUp lookUp){
+        if (lookUp.version > INVALID_VERSION) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * writeValueFinish completes the insertion of a value to Oak. When inserting a value, the value
+     * reference is CASed inside the entry and only then the version is CASed. Thus, there can be a
+     * time in which the entry's value version is INVALID_VERSION or a negative one. In this method,
+     * the version is CASed to complete the insertion.
+     *
+     * writeValueFinish is used in cases when in an entry the value reference and its off-heap and
+     * on-heap versions do not match. In this case it is assumed that we are
+     * in the middle of committing a value write and need to write the off-heap value on-heap.
+     *
+     * <p>
+     * The version written to entry is the version written in the off-heap memory. There is no worry
+     * of concurrent removals since these removals will have to first call this function as well,
+     * and they eventually change the version as well.
+     *
+     * @param lookUp - It holds the entry to CAS, the previously written version of this entry
+     *               and the value reference from which the correct version is read.
+     * @return a version is returned.
+     *
+     * If returned value (version) is {@code INVALID_VERSION} it means that a CAS was not preformed.
+     * Otherwise, a positive version is returned, and it is the version written to the entry
+     * (maybe by some other thread).
+     * <p>
+     * Note 1: the version in the input param {@code lookUp} is updated in this method to be the
+     * updated one if a valid version was returned.
+     *
+     * Note 2: updating of the entries MUST be under published operation. The invoker of this method
+     * is responsible to call it inside the publish/unpublish scope.
+     */
+    int writeValueFinish(LookUp lookUp) { //TODO: check how not to return the version
+        int entryVersion = lookUp.version;
+
+        if (entryVersion > INVALID_VERSION) { // no need to complete a thing
+            return entryVersion;
+        }
+
+        Slice valueSlice = buildValueSlice(lookUp.valueReference);
+        int offHeapVersion = valOffHeapOperator.getOffHeapVersion(valueSlice);
+        casEntriesArrayInt(lookUp.entryIndex, OFFSET.VALUE_VERSION, entryVersion, offHeapVersion);
+        lookUp.version = offHeapVersion;
+        return offHeapVersion;
+    }
+
+    /**
+     * deleteValueFinish completes the deletion of a value in Oak, by marking the value reference in
+     * entry, after the on-heap value was already marked as deleted.
+     *
+     * As written in {@code writeValueFinish(LookUp)}, when updating an entry, the value reference
+     * is CASed first and later the value version, and the same applies when removing a value.
+     * However, there is another step before deleting an entry (remove a value), it is marking
+     * the value off-heap (the LP).
+     *
+     * deleteValueFinish is used to first CAS the value reference to {@code INVALID_VALUE_REFERENCE}
+     * and then CAS the version to be a negative one. Other threads seeing a value marked as deleted
+     * call this function before they proceed (e.g., before performing a successful {@code putIfAbsent}).
+     *
+     * @param lookUp - holds the entry to change, the old value reference to CAS out, and the current value version.
+     * @return true if the deletion indeed updated the entry to be deleted as a unique operation
+     *
+     * Note: updating of the entries MUST be under published operation. The invoker of this method
+     * is responsible to call it inside the publish/unpublish scope.
+     */
+    boolean deleteValueFinish(LookUp lookUp) {
+        int version = lookUp.version;
+        if (version <= INVALID_VERSION) { // version is marked deleted
+            return false;
+        }
+
+        // Scenario: this value space is allocated once again and assigned into the same entry,
+        // while this thread is sleeping. So later a valid value reference is CASed to invalid.
+        // In order to not allow this scenario happen we must release the
+        // TODO: release value's off-heap slice to memory manager only after deleteValueFinish is called.
+        casEntriesArrayLong(lookUp.entryIndex, OFFSET.VALUE_REFERENCE, lookUp.valueReference,
+                    INVALID_VALUE_REFERENCE);
+        return casEntriesArrayInt(lookUp.entryIndex, OFFSET.VALUE_VERSION, version, -version);
+    }
+
+    /**
+     * allocateEntry creates/allocates an entry for the key. An entry is always associated with a key,
+     * therefore the key is written to off-heap and associated with the entry simultaneously.
+     * The value of the new entry is set to NULL: <INVALID_VALUE_REFERENCE, INVALID_VERSION></>
+     **/
+    int allocateEntry(K key) {
+        int ei = numOfEntries.getAndIncrement();
+        if (ei > entriesCapacity) {
+            return INVALID_ENTRY_INDEX;
+        }
+        int intIdx = entryIdx2intIdx(ei);
+        // key and value must be set before returned
+        // setting the value reference to <INVALID_VALUE_REFERENCE, INVALID_VERSION>
+        setEntryFieldLong(intIdx, OFFSET.VALUE_REFERENCE, INVALID_VALUE_REFERENCE);
+        setEntryFieldInt(intIdx, OFFSET.VALUE_VERSION, INVALID_VERSION);
+
+        writeKey(key, ei);
+        return ei;
+    }
+
+    boolean isEntryDeleted(int ei) {
+        int[] valueVersion = new int[1];
+        long valueReference = getValueReferenceAndVersion(ei, valueVersion);
+        return (valueReference == INVALID_VALUE_REFERENCE) ||
+            valOffHeapOperator.isValueDeleted(buildValueSlice(valueReference), valueVersion[0]) != FALSE;
+    }
+
+    /*
+     * isValueRefValid is used only to check whether the value reference, which is part of the
+     * entry on entry index "ei" is valid. No version check and no off-heap value deletion mark check.
+     * Negative version is not checked, because negative version assignment will follow the
+     * invalid reference assignment.
+     * */
+    boolean isValueRefValid(int ei) {
+        return (getValueReference(ei) != INVALID_VALUE_REFERENCE);
+    }
+
+    /******************************************************************/
+    /*
+     * All the functionality that links entries into a linked list or updates the linked list
+     * is provided by the user of the entry set. EntrySet provides the possibility to update the
+     * next entry index via set or CAS, but does it only as a result of the user request.
+     * */
+
+
+    /**
+     * copyEntry copies one entry from source EntrySet (at source entry index "srcEntryIdx") to this EntrySet.
+     * The destination entry index is chosen according to this numOfEntries which is increased with
+     * each copy. Deleted entry (marked on-heap or off-heap) is not copied (disregarded).
+     *
+     * The next pointers of the entries are requested to be set by the user if needed.
+     *
+     * @return true if entry was copied, false otherwise
+     *
+     * NOT THREAD SAFE
+     * */
+    boolean copyEntry(EntrySet<K,V> srcEntrySet, int srcEntryIdx) {
+        if (srcEntryIdx == headNextIndex) {
+            return false;
+        }
+
+        // don't increase the numOfEntries yet, as the source entry might not be copies
+        int destEntryIndex = numOfEntries.get();
+
+        if (destEntryIndex > entriesCapacity) {return false;}
+
+        if (srcEntrySet.isEntryDeleted(srcEntryIdx)) {return false;}
+
+        // ARRAY COPY: using next as the base of the entry
+        // copy both the key and the value references the value's version => 5 integers via array copy
+        // the first field in an entry is next, and it is not copied since it should be assigned elsewhere
+        // therefore, to copy the rest of the entry we use the offset of next (which we assume is 0) and
+        // add 1 to start the copying from the subsequent field of the entry.
+        System.arraycopy(srcEntrySet.entries,  // source entries array
+            entryIdx2intIdx(srcEntryIdx) + OFFSET.NEXT.value + 1,
+            entries,                        // this entries array
+            entryIdx2intIdx(destEntryIndex) + OFFSET.NEXT.value + 1, (FIELDS - 1));
+
+        // now it is the time to increase numOfEntries
+        numOfEntries.getAndIncrement();
+        return true;
+    }
+
+
+}

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -406,8 +406,8 @@ class InternalOakMap<K, V> {
             /* If {@code lookUp == null} i.e., there is no entry with that key in Oak, the previous version
             associated with the entry is INVALID_VERSION.
             Otherwise, there is an entry with the given key and its value is deleted (or at least in the process of
-            being deleted). After calling {@code deleteValueFinish(Chunk<K, V>, LookUp)}, the version of this entry
-            should be negative.
+            being deleted, marked just off-heap). After calling {@code deleteValueFinish(Chunk<K, V>, LookUp)},
+            the version of this entry should be negative.
             Concurrent insertions, however, may cause the version to become valid again.
             Thus, to ensure that the operation behaves as if it itself unlinked the deleted value, we take the minus
             the absolute value of the version written in lookUp (this way, if the version is already negative, it

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -853,7 +853,7 @@ class InternalOakMap<K, V> {
 
         Chunk<K, V> c = findChunk(key);
         EntrySet.LookUp lookUp = c.lookUp(key);
-        if (lookUp == null || lookUp.valueSlice == null || lookUp.entryIndex == INVALID_ENTRY_INDEX) {
+        if (lookUp == null || lookUp.valueSlice == null) {
             return null;
         }
         return c.readKeyFromEntryIndex(lookUp.entryIndex);
@@ -1049,7 +1049,7 @@ class InternalOakMap<K, V> {
 
 
         static <K, V> IteratorState<K, V> newInstance(Chunk<K, V> nextChunk, Chunk.ChunkIter nextChunkIter) {
-            return new IteratorState<>(nextChunk, nextChunkIter, EntrySet.NONE_NEXT);
+            return new IteratorState<>(nextChunk, nextChunkIter, NONE_NEXT);
         }
 
     }

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -380,7 +380,7 @@ class InternalOakMap<K, V> {
             /* If {@code lookUp == null} i.e., there is no entry with that key in Oak, the previous version
             associated with the entry is INVALID_VERSION.
             Otherwise, there is an entry with the given key and its value is deleted (or at least in the process of
-            being deleted). After calling {@code finalizeDeletion(Chunk<K, V>, LookUp)}, the version of this entry
+            being deleted). After calling {@code deleteValueFinish(Chunk<K, V>, LookUp)}, the version of this entry
             should be negative.
             Concurrent insertions, however, may cause the version to become valid again.
             Thus, to ensure that the operation behaves as if it itself unlinked the deleted value, we take the minus
@@ -470,7 +470,7 @@ class InternalOakMap<K, V> {
             /* If {@code lookUp == null} i.e., there is no entry with that key in Oak, the previous version
             associated with the entry is INVALID_VERSION.
             Otherwise, there is an entry with the given key and its value is deleted (or at least in the process of
-            being deleted). After calling {@code finalizeDeletion(Chunk<K, V>, LookUp)}, the version of this entry
+            being deleted). After calling {@code deleteValueFinish(Chunk<K, V>, LookUp)}, the version of this entry
             should be negative.
             Concurrent insertions, however, may cause the version to become valid again.
             Thus, to ensure that the operation behaves as if it itself unlinked the deleted value, we take the minus
@@ -571,7 +571,7 @@ class InternalOakMap<K, V> {
             /* If {@code lookUp == null} i.e., there is no entry with that key in Oak, the previous version
             associated with the entry is INVALID_VERSION.
             Otherwise, there is an entry with the given key and its value is deleted (or at least in the process of
-            being deleted). After calling {@code finalizeDeletion(Chunk<K, V>, LookUp)}, the version of this entry
+            being deleted). After calling {@code deleteValueFinish(Chunk<K, V>, LookUp)}, the version of this entry
             should be negative.
             Concurrent insertions, however, may cause the version to become valid again.
             Thus, to ensure that the operation behaves as if it itself unlinked the deleted value, we take the minus

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -413,11 +413,9 @@ class InternalOakMap<K, V> {
             the absolute value of the version written in lookUp (this way, if the version is already negative, it
             remains negative).
              */
-            int ei;
             if (lookUp != null) {
                 lookUp.version = -Math.abs(lookUp.version);
-                ei = lookUp.entryIndex;
-                assert ei > 0;
+                assert lookUp.entryIndex > 0;
             } else {
                 // lookUp is null so there was no such key found, while EntrySet allocates the entry
                 // (holding the key) the new lookUp is going to be returned to be used by EntrySet's
@@ -505,14 +503,12 @@ class InternalOakMap<K, V> {
             the absolute value of the version written in lookUp (this way, if the version is already negative, it
             remains negative).
              */
-            int ei;
             if (lookUp != null) {
                 // There's an entry for this key, but it isn't linked to any value (in which case valueReference is
                 // DELETED_VALUE)
                 // or it's linked to a deleted value that is referenced by valueReference (a valid one)
                 lookUp.version = -Math.abs(lookUp.version);
-                ei = lookUp.entryIndex;
-                assert ei > 0;
+                assert lookUp.entryIndex > 0;
             } else {
                 // lookUp is null so there was no such key found, while EntrySet allocates the entry
                 // (holding the key) the new lookUp is going to be returned to be used by EntrySet's
@@ -613,11 +609,9 @@ class InternalOakMap<K, V> {
             // 1. no entry in the linked list at all
             // 2. entry in the linked list, but the value reference is INVALID_VALUE_REFERENCE
             // 3. entry in the linked list, the value referenced is marked as deleted
-            int ei;
             if (lookUp != null) {
                 lookUp.version = -Math.abs(lookUp.version);
-                ei = lookUp.entryIndex;
-                assert ei > 0;
+                assert lookUp.entryIndex > 0;
             } else {
                 // lookUp is null so there was no such key found, while EntrySet allocates the entry
                 // (holding the key) the new lookUp is going to be returned to be used by EntrySet's

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -431,7 +431,7 @@ class InternalOakMap<K, V> {
                     // If this entry (with index prevEi) is valid we should move to continue
                     // with existing entry scenario, otherwise we can reuse this entry because
                     // its value is invalid.
-                    c.releaseKey(lookUp.entryIndex);
+                    c.releaseKey(lookUp);
                     if (!c.isValueRefValid(prevEi)) {
                         continue;
                     }
@@ -523,7 +523,7 @@ class InternalOakMap<K, V> {
                     // our entry wasn't inserted because other entry with same key was found.
                     // If this entry (with index prevEi) is valid we should return false,
                     // otherwise we can reuse this entry because its value is invalid.
-                    c.releaseKey(lookUp.entryIndex);
+                    c.releaseKey(lookUp);
                     // for non-zc interface putIfAbsent returns the previous value associated with
                     // the specified key, or null if there was no mapping for the key.
                     // so we need to create a slice to let transformer create the value object
@@ -627,7 +627,7 @@ class InternalOakMap<K, V> {
                     // If this entry (with index prevEi) is valid we should move to continue
                     // with existing entry scenario (compute), otherwise we can reuse this entry because
                     // its value is invalid.
-                    c.releaseKey(lookUp.entryIndex);
+                    c.releaseKey(lookUp);
                     if (c.isValueRefValid(prevEi)) {
                         continue;
                     } else {

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -160,6 +160,30 @@ class InternalOakMap<K, V> {
         return c;
     }
 
+    Slice overwriteExistingValueForMove(EntrySet.LookUp lookUp, V newVal, Chunk<K, V> c) {
+        // given old entry index (inside lookUp) and new value, while old value is locked,
+        // allocate new value, new value is going to be locked as well, write the new value
+        EntrySet.OpData opData = c.writeValue(lookUp, newVal, true);
+
+        // in order to connect/overwrite the old entry to point to new value
+        // we need to publish as in the normal write process
+        if (!c.publish()) {
+            c.releaseValue(opData);
+            rebalance(c);
+            return null;
+        }
+
+        // updating the old entry index
+        if (c.linkValue(opData, true) != TRUE) {
+            c.releaseValue(opData);
+            c.unpublish();
+            return null;
+        }
+
+        c.unpublish();
+        checkRebalance(c);
+        return opData.slice;
+    }
 
     /**
      * @param c - Chunk to rebalance
@@ -169,7 +193,7 @@ class InternalOakMap<K, V> {
         if (c == null) {
             return;
         }
-        Rebalancer<K, V> rebalancer = new Rebalancer<>(c, true, memoryManager, keySerializer,
+        Rebalancer<K, V> rebalancer = new Rebalancer<>(c, memoryManager, keySerializer,
                 valueSerializer, valueOperator);
 
         rebalancer = rebalancer.engageChunks(); // maybe we encountered a different rebalancer
@@ -314,7 +338,7 @@ class InternalOakMap<K, V> {
         return false;
     }
 
-    private boolean finalizeDeletion(Chunk<K, V> c, LookUp lookUp) {
+    private boolean finalizeDeletion(Chunk<K, V> c, EntrySet.LookUp lookUp) {
         if (lookUp != null) {
             if (c.finalizeDeletion(lookUp)) {
                 rebalance(c);
@@ -325,15 +349,16 @@ class InternalOakMap<K, V> {
     }
 
     /**
-     * This function completes the insertion of the value reference in the variable {@code lookUp}, and updates the
-     * value's version in {@code lookUp}. In case, the linking cannot be done (i.e., a concurrent rebalance), than
+     * This function completes the insertion of the value reference to the entry
+     * (reflected in {@code lookUp}), and updates the value's version in {@code lookUp} IF NEEDED.
+     * In case, the linking cannot be done (i.e., a concurrent rebalance), than
      * rebalance is called.
      *
      * @param c      - the chuck pointed by {@code lookUp}
      * @param lookUp - holds the value reference, old version, and relevant entry to update
      * @return whether the caller method should restart (if a rebalance was executed).
      */
-    private boolean updateVersionAfterLinking(Chunk<K, V> c, LookUp lookUp) {
+    private boolean updateVersionAfterLinking(Chunk<K, V> c, EntrySet.LookUp lookUp) {
         if (c.completeLinking(lookUp) == INVALID_VERSION) {
             rebalance(c);
             return true;
@@ -356,14 +381,15 @@ class InternalOakMap<K, V> {
                 assert false;
             }
             Chunk<K, V> c = findChunk(key); // find chunk matching key
-            Chunk.LookUp lookUp = c.lookUp(key);
+            EntrySet.LookUp lookUp = c.lookUp(key);
             // If there is a matching value reference for the given key, and it is not marked as deleted, then this put
             // changes the slice pointed by this value reference.
             if (lookUp != null && lookUp.valueSlice != null) {
                 if (updateVersionAfterLinking(c, lookUp)) {
                     continue;
                 }
-                Result<V> res = valueOperator.exchange(c, lookUp, value, transformer, valueSerializer, memoryManager);
+                Result<V> res = valueOperator.exchange(c, lookUp, value, transformer, valueSerializer, memoryManager,
+                    this);
                 if (res.operationResult == TRUE) {
                     return res.value;
                 }
@@ -387,48 +413,50 @@ class InternalOakMap<K, V> {
             the absolute value of the version written in lookUp (this way, if the version is already negative, it
             remains negative).
              */
-            int oldVersion = lookUp == null ? INVALID_VERSION : -Math.abs(lookUp.version);
-
             int ei;
             if (lookUp != null) {
+                lookUp.version = -Math.abs(lookUp.version);
                 ei = lookUp.entryIndex;
                 assert ei > 0;
             } else {
-                ei = c.allocateEntryAndKey(key);
-                if (ei == INVALID_ENTRY_INDEX) {
+                // lookUp is null so there was no such key found, while EntrySet allocates the entry
+                // (holding the key) the new lookUp is going to be returned to be used by EntrySet's
+                // subsequent requests to write value
+                lookUp = c.allocateEntryAndKey(key);
+                if (lookUp == null) {
                     rebalance(c);
                     continue;
                 }
-                int prevEi = c.linkEntry(ei, key);
-                if (prevEi != ei) {
-                    c.releaseKey(ei);
-                    if (c.getValueReference(prevEi) != INVALID_VALUE_REFERENCE) {
+                int prevEi = c.linkEntry(lookUp, key);
+                if (prevEi != lookUp.entryIndex) {
+                    // our entry wasn't inserted because other entry with same key was found.
+                    // If this entry (with index prevEi) is valid we should move to continue
+                    // with existing entry scenario, otherwise we can reuse this entry because
+                    // its value is invalid.
+                    c.releaseKey(lookUp.entryIndex);
+                    if (!c.isValueRefValid(prevEi)) {
                         continue;
                     }
-                    // We use an existing entry only if its value reference is INVALID_VALUE_REFERENCE
-                    ei = prevEi;
+                    // We use an existing entry only if its value reference is invalid
+                    lookUp.entryIndex = prevEi;
                 }
             }
 
-            int[] version = new int[1];
-            long newValueReference = c.writeValue(value, version); // write value in place
-
-            Chunk.OpData opData = new Chunk.OpData(ei, INVALID_VALUE_REFERENCE, newValueReference, oldVersion,
-                    version[0]);
+            EntrySet.OpData opData = c.writeValue(lookUp, value, false); // write value in place
 
             if (!c.publish()) {
-                c.releaseValue(newValueReference);
+                c.releaseValue(opData);
                 rebalance(c);
                 continue;
             }
 
-            if (c.linkValue(opData) != TRUE) {
-                c.releaseValue(newValueReference);
+            if (c.linkValue(opData, false) != TRUE) {
+                c.releaseValue(opData);
                 c.unpublish();
             } else {
                 c.unpublish();
                 checkRebalance(c);
-                return null;
+                return null; // null can be returned only in zero-copy case
             }
         }
     }
@@ -446,7 +474,7 @@ class InternalOakMap<K, V> {
                 assert false;
             }
             Chunk<K, V> c = findChunk(key); // find chunk matching key
-            Chunk.LookUp lookUp = c.lookUp(key);
+            EntrySet.LookUp lookUp = c.lookUp(key);
 
             if (lookUp != null && lookUp.valueSlice != null) {
                 if (updateVersionAfterLinking(c, lookUp)) {
@@ -477,32 +505,38 @@ class InternalOakMap<K, V> {
             the absolute value of the version written in lookUp (this way, if the version is already negative, it
             remains negative).
              */
-            int oldVersion = lookUp == null ? INVALID_VERSION : -Math.abs(lookUp.version);
-
             int ei;
             if (lookUp != null) {
                 // There's an entry for this key, but it isn't linked to any value (in which case valueReference is
                 // DELETED_VALUE)
                 // or it's linked to a deleted value that is referenced by valueReference (a valid one)
+                lookUp.version = -Math.abs(lookUp.version);
                 ei = lookUp.entryIndex;
                 assert ei > 0;
             } else {
-                ei = c.allocateEntryAndKey(key);
-                if (ei == INVALID_ENTRY_INDEX) {
+                // lookUp is null so there was no such key found, while EntrySet allocates the entry
+                // (holding the key) the new lookUp is going to be returned to be used by EntrySet's
+                // subsequent requests to write value
+                lookUp = c.allocateEntryAndKey(key);
+                if (lookUp == null) {
                     rebalance(c);
                     continue;
                 }
-                int prevEi = c.linkEntry(ei, key);
-                if (prevEi != ei) {
-                    c.releaseKey(ei);
-                    // some other thread linked its entry with the same key.
-                    int[] otherVersion = new int[1];
-                    Slice otherSlice = c.buildValueSlice(c.getValueReferenceAndVersion(prevEi, otherVersion));
+                int prevEi = c.linkEntry(lookUp, key);
+                if (prevEi != lookUp.entryIndex) {
+                    // our entry wasn't inserted because other entry with same key was found.
+                    // If this entry (with index prevEi) is valid we should return false,
+                    // otherwise we can reuse this entry because its value is invalid.
+                    c.releaseKey(lookUp.entryIndex);
+                    // for non-zc interface putIfAbsent returns the previous value associated with
+                    // the specified key, or null if there was no mapping for the key.
+                    // so we need to create a slice to let transformer create the value object
+                    Slice otherSlice = c.buildValueSlice(prevEi);
                     if (otherSlice != null) {
                         if (transformer == null) {
                             return Result.withFlag(FALSE);
                         }
-                        Result<V> res = valueOperator.transform(otherSlice, transformer, otherVersion[0]);
+                        Result<V> res = valueOperator.transform(otherSlice, transformer, otherSlice.getVersion());
                         if (res.operationResult == TRUE) {
                             return res;
                         }
@@ -514,20 +548,16 @@ class InternalOakMap<K, V> {
                 }
             }
 
-            int[] version = new int[1];
-            long newValueReference = c.writeValue(value, version); // write value in place
-
-            Chunk.OpData opData = new Chunk.OpData(ei, INVALID_VALUE_REFERENCE, newValueReference, oldVersion,
-                    version[0]);
+            EntrySet.OpData opData = c.writeValue(lookUp, value, false); // write value in place
 
             if (!c.publish()) {
-                c.releaseValue(newValueReference);
+                c.releaseValue(opData);
                 rebalance(c);
                 continue;
             }
 
-            if (c.linkValue(opData) != TRUE) {
-                c.releaseValue(newValueReference);
+            if (c.linkValue(opData, false) != TRUE) {
+                c.releaseValue(opData);
                 c.unpublish();
             } else {
                 c.unpublish();
@@ -550,7 +580,7 @@ class InternalOakMap<K, V> {
                 assert false;
             }
             Chunk<K, V> c = findChunk(key); // find chunk matching key
-            Chunk.LookUp lookUp = c.lookUp(key);
+            EntrySet.LookUp lookUp = c.lookUp(key);
             if (lookUp != null && lookUp.valueSlice != null) {
                 if (updateVersionAfterLinking(c, lookUp)) {
                     continue;
@@ -578,7 +608,6 @@ class InternalOakMap<K, V> {
             the absolute value of the version written in lookUp (this way, if the version is already negative, it
             remains negative).
              */
-            int oldVersion = lookUp == null ? INVALID_VERSION : -Math.abs(lookUp.version);
 
             // we come here when no key was found, which can be in 3 cases:
             // 1. no entry in the linked list at all
@@ -586,18 +615,27 @@ class InternalOakMap<K, V> {
             // 3. entry in the linked list, the value referenced is marked as deleted
             int ei;
             if (lookUp != null) {
+                lookUp.version = -Math.abs(lookUp.version);
                 ei = lookUp.entryIndex;
                 assert ei > 0;
             } else {
-                ei = c.allocateEntryAndKey(key);
-                if (ei == INVALID_ENTRY_INDEX) {
+                // lookUp is null so there was no such key found, while EntrySet allocates the entry
+                // (holding the key) the new lookUp is going to be returned to be used by EntrySet's
+                // subsequent requests to write value
+                lookUp = c.allocateEntryAndKey(key);
+                if (lookUp == null) {
                     rebalance(c);
                     continue;
                 }
-                int prevEi = c.linkEntry(ei, key);
-                if (prevEi != ei) {
-                    c.releaseKey(ei);
-                    if (c.getValueReference(prevEi) != INVALID_VALUE_REFERENCE) {
+                int prevEi = c.linkEntry(lookUp, key);
+                // our entry wasn't inserted because other entry with same key was found.
+                // If this entry (with index prevEi) is valid we should move to continue
+                // with existing entry scenario (compute), otherwise we can reuse this entry because
+                // its value is invalid.
+                c.releaseKey(lookUp.entryIndex);
+                if (prevEi != lookUp.entryIndex) {
+                    c.releaseKey(lookUp.entryIndex);
+                    if (c.isValueRefValid(prevEi)) {
                         continue;
                     } else {
                         ei = prevEi;
@@ -605,20 +643,16 @@ class InternalOakMap<K, V> {
                 }
             }
 
-            int[] version = new int[1];
-            long newValueReference = c.writeValue(value, version); // write value in place
-
-            Chunk.OpData opData = new Chunk.OpData(ei, INVALID_VALUE_REFERENCE, newValueReference, oldVersion,
-                    version[0]);
+            EntrySet.OpData opData = c.writeValue(lookUp, value, false); // write value in place
 
             if (!c.publish()) {
-                c.releaseValue(newValueReference);
+                c.releaseValue(opData);
                 rebalance(c);
                 continue;
             }
 
-            if (c.linkValue(opData) != TRUE) {
-                c.releaseValue(newValueReference);
+            if (c.linkValue(opData, false) != TRUE) {
+                c.releaseValue(opData);
                 c.unpublish();
             } else {
                 c.unpublish();
@@ -646,7 +680,7 @@ class InternalOakMap<K, V> {
                 assert false;
             }
             Chunk<K, V> c = findChunk(key); // find chunk matching key
-            Chunk.LookUp lookUp = c.lookUp(key);
+            EntrySet.LookUp lookUp = c.lookUp(key);
 
             if (lookUp == null) {
                 // There is no such key. If we did logical deletion and someone else did the physical deletion,
@@ -684,7 +718,7 @@ class InternalOakMap<K, V> {
             }
 
             assert lookUp.entryIndex > 0;
-            assert lookUp.valueReference != INVALID_VALUE_REFERENCE;
+            assert c.isValueRefValid(lookUp.entryIndex);
 
             // publish
             if (c.finalizeDeletion(lookUp)) {
@@ -705,15 +739,15 @@ class InternalOakMap<K, V> {
                 assert false;
             }
             Chunk<K, V> c = findChunk(key); // find chunk matching key
-            Chunk.LookUp lookUp = c.lookUp(key);
+            EntrySet.LookUp lookUp = c.lookUp(key);
             if (lookUp == null || lookUp.valueSlice == null) {
                 return null;
             }
             if (updateVersionAfterLinking(c, lookUp)) {
                 continue;
             }
-            long keyReference = c.getKeyReference(lookUp.entryIndex);
-            return new OakRValueBufferImpl(lookUp.valueReference, lookUp.version, keyReference, valueOperator,
+
+            return new OakRValueBufferImpl(lookUp.valueReference, lookUp.version, lookUp.keyReference, valueOperator,
                     memoryManager, this);
         }
     }
@@ -731,7 +765,7 @@ class InternalOakMap<K, V> {
                 assert false;
             }
             Chunk<K, V> c = findChunk(key); // find chunk matching key
-            Chunk.LookUp lookUp = c.lookUp(key);
+            EntrySet.LookUp lookUp = c.lookUp(key);
 
             if (lookUp != null && lookUp.valueSlice != null) {
                 if (updateVersionAfterLinking(c, lookUp)) {
@@ -750,11 +784,13 @@ class InternalOakMap<K, V> {
         }
     }
 
-    LookUp getValueFromIndex(long keyReference) {
+    // used when value of a key was possibly moved and we try to search for the given key
+    // through the OakMap again
+    EntrySet.LookUp refreshValuePosition(long keyReference) {
         K deserializedKey = keySerializer.deserialize(getKeyByteBuffer(keyReference));
         while (true) {
             Chunk<K, V> c = findChunk(deserializedKey); // find chunk matching key
-            Chunk.LookUp lookUp = c.lookUp(deserializedKey);
+            EntrySet.LookUp lookUp = c.lookUp(deserializedKey);
             if (lookUp == null || lookUp.valueSlice == null) {
                 return null;
             }
@@ -784,7 +820,7 @@ class InternalOakMap<K, V> {
                 assert false;
             }
             Chunk<K, V> c = findChunk(key); // find chunk matching key
-            Chunk.LookUp lookUp = c.lookUp(key);
+            EntrySet.LookUp lookUp = c.lookUp(key);
             if (lookUp == null || lookUp.valueSlice == null) {
                 return null;
             }
@@ -809,17 +845,18 @@ class InternalOakMap<K, V> {
         return transformer.apply(serializedKey.slice().asReadOnlyBuffer());
     }
 
+    // Returns the buffer of key and not value as usual
     private ByteBuffer getKey(K key) {
         if (key == null) {
             throw new NullPointerException();
         }
 
         Chunk<K, V> c = findChunk(key);
-        Chunk.LookUp lookUp = c.lookUp(key);
+        EntrySet.LookUp lookUp = c.lookUp(key);
         if (lookUp == null || lookUp.valueSlice == null || lookUp.entryIndex == INVALID_ENTRY_INDEX) {
             return null;
         }
-        return c.readKey(lookUp.entryIndex);
+        return c.readKeyFromEntryIndex(lookUp.entryIndex);
     }
 
     ByteBuffer getMinKey() {
@@ -885,14 +922,14 @@ class InternalOakMap<K, V> {
                 assert false;
             }
             Chunk<K, V> c = findChunk(key); // find chunk matching key
-            Chunk.LookUp lookUp = c.lookUp(key);
+            EntrySet.LookUp lookUp = c.lookUp(key);
             if (lookUp == null || lookUp.valueSlice == null) {
                 return null;
             }
 
             // will return null if the value is deleted
             Result<V> result = valueOperator.exchange(c, lookUp, value, valueDeserializeTransformer, valueSerializer,
-                    memoryManager);
+                    memoryManager, this);
             if (result.operationResult != RETRY) {
                 return result.value;
             }
@@ -908,13 +945,13 @@ class InternalOakMap<K, V> {
                 assert false;
             }
             Chunk<K, V> c = findChunk(key); // find chunk matching key
-            Chunk.LookUp lookUp = c.lookUp(key);
+            EntrySet.LookUp lookUp = c.lookUp(key);
             if (lookUp == null || lookUp.valueSlice == null) {
                 return false;
             }
 
             ValueUtils.ValueResult res = valueOperator.compareExchange(c, lookUp, oldValue, newValue,
-                    valueDeserializeTransformer, valueSerializer, memoryManager);
+                    valueDeserializeTransformer, valueSerializer, memoryManager, this);
             if (res == RETRY) {
                 continue;
             }
@@ -936,7 +973,7 @@ class InternalOakMap<K, V> {
 
         while (chunkIter.hasNext()) {
             int nextIndex = chunkIter.next();
-            int cmp = comparator.compareKeyAndSerializedKey(key, c.readKey(nextIndex));
+            int cmp = comparator.compareKeyAndSerializedKey(key, c.readKeyFromEntryIndex(nextIndex));
             if (cmp <= 0) {
                 break;
             }
@@ -945,20 +982,20 @@ class InternalOakMap<K, V> {
 
         /* Edge case: we're looking for the lowest key in the map and it's still greater than minkey
             (in which  case prevKey == key) */
-        ByteBuffer prevKey = c.readKey(prevIndex);
+        ByteBuffer prevKey = c.readKeyFromEntryIndex(prevIndex);
         if (comparator.compareKeyAndSerializedKey(key, prevKey) == 0) {
             return new AbstractMap.SimpleImmutableEntry<>(null, null);
         }
         K keyDeserialized = keySerializer.deserialize(prevKey.slice());
 
-        int[] valueVersion = new int[1];
-        long valueReference = c.getValueReferenceAndVersion(prevIndex, valueVersion);
-        if (valueReference == INVALID_VALUE_REFERENCE) {
+        // get value associated with this (prev) key
+        Slice valueSlice = c.buildValueSlice(prevIndex);
+        if (valueSlice == null){ // value reference was invalid, try again
             return lowerEntry(key);
         }
-        Result<V> valueDeserialized = valueOperator.transform(getValueSlice(valueReference),
+        Result<V> valueDeserialized = valueOperator.transform(valueSlice,
                 valueSerializer::deserialize,
-                valueVersion[0]);
+                valueSlice.getVersion());
         if (valueDeserialized.operationResult != TRUE) {
             return lowerEntry(key);
         }
@@ -967,28 +1004,16 @@ class InternalOakMap<K, V> {
 
     /*-------------- Iterators --------------*/
 
-    private Slice getValueSlice(long valuerReference) {
-        if (valuerReference == INVALID_VALUE_REFERENCE) {
-            return null;
-        }
-        int[] valueArray = UnsafeUtils.longToInts(valuerReference);
-        return memoryManager.getSliceFromBlockID(valueArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> VALUE_BLOCK_SHIFT,
-                valueArray[POSITION_ARRAY_INDEX], valueArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & VALUE_LENGTH_MASK);
+    private Slice getValueSlice(long valuerReference, int version) {
+        return EntrySet.buildValueSlice(valuerReference, version, memoryManager);
     }
 
     private ByteBuffer getKeyByteBuffer(long keyReference) {
-        int[] keyArray = UnsafeUtils.longToInts(keyReference);
-        return memoryManager.getByteBufferFromBlockID(keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> KEY_BLOCK_SHIFT,
-                keyArray[POSITION_ARRAY_INDEX], keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK);
+        return EntrySet.keyRefToByteBuffer(keyReference, memoryManager);
     }
 
     private OakRReference setKeyReference(long keyReference, OakRReference key) {
-        int[] keyArray = UnsafeUtils.longToInts(keyReference);
-        int blockID = keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >> KEY_BLOCK_SHIFT;
-        int keyPosition = keyArray[POSITION_ARRAY_INDEX];
-        int length = keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK;
-
-        key.setReference(blockID, keyPosition, length);
+        EntrySet.keyRefToOakRRef(keyReference, key);
         return key;
     }
 
@@ -1024,7 +1049,7 @@ class InternalOakMap<K, V> {
 
 
         static <K, V> IteratorState<K, V> newInstance(Chunk<K, V> nextChunk, Chunk.ChunkIter nextChunkIter) {
-            return new IteratorState<>(nextChunk, nextChunkIter, Chunk.NONE);
+            return new IteratorState<>(nextChunk, nextChunkIter, EntrySet.NONE_NEXT);
         }
 
     }
@@ -1115,7 +1140,8 @@ class InternalOakMap<K, V> {
 
         private void initAfterRebalance() {
             //TODO - refactor to use ByeBuffer without deserializing.
-            K nextKey = keySerializer.deserialize(state.getChunk().readKey(state.getIndex()).slice());
+            K nextKey = keySerializer.deserialize(
+                state.getChunk().readKeyFromEntryIndex(state.getIndex()).slice());
 
             if (isDescending) {
                 hiInclusive = true;
@@ -1159,22 +1185,20 @@ class InternalOakMap<K, V> {
             if (chunkState == Chunk.State.RELEASED) {
                 initAfterRebalance();
             }
+            EntrySet.LookUp lookUp = state.getChunk().buildLookUp(state.getIndex());
 
-            long keyReference = state.getChunk().getKeyReference(state.getIndex());
-            long valueReference;
-            int[] valueVersion = new int[1];
+
             if (needsValue) {
-                valueReference = state.getChunk().getValueReferenceAndVersion(state.getIndex(), valueVersion);
-                if (valueReference != INVALID_VALUE_REFERENCE) {
-                    valueVersion[0] = state.getChunk().completeLinking(new LookUp(null, valueReference,
-                            state.getIndex(), valueVersion[0]));
+
+                if (lookUp.valueReference != EntrySet.INVALID_VALUE_REFERENCE) {
+                    lookUp.version = state.getChunk().completeLinking(lookUp);
                     // The CAS could not complete due to concurrent rebalance, so rebalance and try again
-                    if (valueVersion[0] == INVALID_VERSION) {
+                    if (lookUp.version == INVALID_VERSION) {
                         rebalance(state.getChunk());
                         return advance(true);
                     }
                     // If we could not complete the linking or if the value is deleted, advance to the next value
-                    if (valueOperator.isValueDeleted(getValueSlice(valueReference), valueVersion[0]) != FALSE) {
+                    if (valueOperator.isValueDeleted(lookUp.valueSlice, lookUp.version) != FALSE) {
                         advanceState();
                         return advance(true);
                     }
@@ -1182,11 +1206,11 @@ class InternalOakMap<K, V> {
                     advanceState();
                     return advance(true);
                 }
-                myItem.valueReference = valueReference;
-                myItem.valueVersion = valueVersion[0];
+                myItem.valueReference = lookUp.valueReference;
+                myItem.valueVersion = lookUp.version;
             }
             advanceState();
-            myItem.keyReference = keyReference;
+            myItem.keyReference = lookUp.keyReference;
             return myItem;
         }
 
@@ -1199,18 +1223,18 @@ class InternalOakMap<K, V> {
             if (state == null) {
                 throw new NoSuchElementException();
             }
-
-            Chunk.State chunkState = state.getChunk().state();
+            Chunk c = state.getChunk();
+            Chunk.State chunkState = c.state();
 
             if (chunkState == Chunk.State.RELEASED) {
                 initAfterRebalance();
             }
             if (key != null) {
-                state.getChunk().setKeyRefer(state.getIndex(), key);
+                c.setKeyReference(state.getIndex(), key);
             }
             // if there a reference to update (this if is not executed for KeyStreamIterator)
             if (value != null) {
-                if (!state.getChunk().setValueRefer(state.getIndex(), value)) {
+                if (!state.getChunk().setValueReference(state.getIndex(), value)) {
                     // If the current value is deleted, then advance and try again
                     advanceState();
                     return advanceStream(key, value);
@@ -1300,7 +1324,7 @@ class InternalOakMap<K, V> {
             // meaning not on the full scan.
             // The check of the boundaries under condition is an optimization.
             if ((hi != null && !isDescending) || (lo != null && isDescending)) {
-                ByteBuffer key = state.getChunk().readKey(state.getIndex());
+                ByteBuffer key = state.getChunk().readKeyFromEntryIndex(state.getIndex());
                 if (!inBounds(key)) {
                     state = null;
                     return;
@@ -1362,7 +1386,7 @@ class InternalOakMap<K, V> {
             IterItem myItem = advance(true);
             long keyReference = myItem.keyReference;
             long valueReference = myItem.valueReference;
-            Slice valueSlice = getValueSlice(valueReference);
+            Slice valueSlice = getValueSlice(valueReference, myItem.valueVersion);
             int version = myItem.valueVersion;
             Result<T> res = valueOperator.transform(valueSlice, transformer, version);
             // If this value is deleted, try the next one
@@ -1451,7 +1475,7 @@ class InternalOakMap<K, V> {
             IterItem myItem = advance(true);
             long keyReference = myItem.keyReference;
             long valueReference = myItem.valueReference;
-            Slice valueSlice = getValueSlice(valueReference);
+            Slice valueSlice = getValueSlice(valueReference, myItem.valueVersion);
             int version = myItem.valueVersion;
             assert valueSlice != null;
             ValueUtils.ValueResult res = valueOperator.lockRead(valueSlice, version);
@@ -1460,7 +1484,7 @@ class InternalOakMap<K, V> {
                 return next();
             } else if (res == RETRY) {
                 do {
-                    LookUp lookUp = getValueFromIndex(keyReference);
+                    EntrySet.LookUp lookUp = refreshValuePosition(keyReference);
                     if (lookUp == null || lookUp.valueSlice == null) {
                         return next();
                     }
@@ -1478,7 +1502,7 @@ class InternalOakMap<K, V> {
                     new AbstractMap.SimpleEntry<>(getKeyByteBuffer(keyReference).asReadOnlyBuffer(), serializedValue);
 
             T transformation = transformer.apply(entry);
-            valueSlice = getValueSlice(valueReference);
+            valueSlice = getValueSlice(valueReference, version);
             valueOperator.unlockRead(valueSlice, version);
             return transformation;
         }

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -718,7 +718,7 @@ class InternalOakMap<K, V> {
             }
 
             assert lookUp.entryIndex > 0;
-            assert c.isValueRefValid(lookUp.entryIndex);
+            assert lookUp.valueReference != EntrySet.INVALID_VALUE_REFERENCE;
 
             // publish
             if (c.finalizeDeletion(lookUp)) {

--- a/core/src/main/java/com/oath/oak/MemoryManager.java
+++ b/core/src/main/java/com/oath/oak/MemoryManager.java
@@ -39,7 +39,9 @@ public interface MemoryManager extends Closeable {
     void releaseSlice(Slice s);
 
     default Slice getSliceFromBlockID(int blockID, int bufferPosition, int bufferLength) {
-        return new Slice(blockID, getByteBufferFromBlockID(blockID, bufferPosition, bufferLength));
+        return new Slice(
+            blockID,
+            getByteBufferFromBlockID(blockID, bufferPosition, bufferLength));
     }
 
     /**

--- a/core/src/main/java/com/oath/oak/NativeAllocator/BlocksPool.java
+++ b/core/src/main/java/com/oath/oak/NativeAllocator/BlocksPool.java
@@ -100,8 +100,10 @@ class BlocksPool implements BlocksProvider, Closeable {
         blocks.add(b);
         if (blocks.size() > EXCESS_POOL_RATIO * NUMBER_OF_BLOCKS) { // too many unused blocks
             synchronized (BlocksPool.class) { // can be easily changed to lock-free
-                for (int i = 0; i < NUMBER_OF_BLOCKS; i++) {
-                    this.blocks.poll().clean();
+                if (blocks.size() > EXCESS_POOL_RATIO * NUMBER_OF_BLOCKS) { // check after locking
+                    for (int i = 0; i < NUMBER_OF_BLOCKS; i++) {
+                        this.blocks.poll().clean();
+                    }
                 }
             }
         }

--- a/core/src/main/java/com/oath/oak/NovaManager.java
+++ b/core/src/main/java/com/oath/oak/NovaManager.java
@@ -49,6 +49,7 @@ public class NovaManager implements MemoryManager {
     @Override
     public Slice allocateSlice(int size, Allocate allocate) {
         Slice s = allocator.allocateSlice(size, allocate);
+        s.setVersion(globalNovaNumber.get());
         assert s.getByteBuffer().remaining() >= size;
         return s;
     }

--- a/core/src/main/java/com/oath/oak/OakRKeyBufferImpl.java
+++ b/core/src/main/java/com/oath/oak/OakRKeyBufferImpl.java
@@ -10,11 +10,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.function.Function;
 
-import static com.oath.oak.Chunk.BLOCK_ID_LENGTH_ARRAY_INDEX;
-import static com.oath.oak.Chunk.KEY_BLOCK_SHIFT;
-import static com.oath.oak.Chunk.KEY_LENGTH_MASK;
-import static com.oath.oak.Chunk.POSITION_ARRAY_INDEX;
-
 public class OakRKeyBufferImpl implements OakRBuffer {
 
     private final long keyReference;
@@ -24,18 +19,16 @@ public class OakRKeyBufferImpl implements OakRBuffer {
     OakRKeyBufferImpl(long keyReference, MemoryManager memoryManager) {
         this.keyReference = keyReference;
         this.memoryManager = memoryManager;
-        this.initialPosition = UnsafeUtils.longToInts(keyReference)[POSITION_ARRAY_INDEX];
+        this.initialPosition = getKeyBuffer().position();
     }
 
     private ByteBuffer getKeyBuffer() {
-        int[] keyArray = UnsafeUtils.longToInts(keyReference);
-        return memoryManager.getByteBufferFromBlockID(keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] >>> KEY_BLOCK_SHIFT, keyArray[POSITION_ARRAY_INDEX],
-                keyArray[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK);
+        return EntrySet.keyRefToByteBuffer(keyReference, memoryManager);
     }
 
     @Override
     public int capacity() {
-        return UnsafeUtils.longToInts(keyReference)[BLOCK_ID_LENGTH_ARRAY_INDEX] & KEY_LENGTH_MASK;
+        return getKeyBuffer().capacity();
     }
 
     @Override

--- a/core/src/main/java/com/oath/oak/Rebalancer.java
+++ b/core/src/main/java/com/oath/oak/Rebalancer.java
@@ -34,7 +34,6 @@ class Rebalancer<K, V> {
     private Chunk<K, V> last;
     private int chunksInRange;
     private int itemsInRange;
-    private final boolean offHeap;
     private final MemoryManager memoryManager;
     private final OakSerializer<K> keySerializer;
     private final OakSerializer<V> valueSerializer;
@@ -42,12 +41,11 @@ class Rebalancer<K, V> {
 
     /*-------------- Constructors --------------*/
 
-    Rebalancer(Chunk<K, V> chunk, boolean offHeap, MemoryManager memoryManager,
-               OakSerializer<K> keySerializer, OakSerializer<V> valueSerializer, ValueUtils valueOperator) {
+    Rebalancer(Chunk<K, V> chunk, MemoryManager memoryManager, OakSerializer<K> keySerializer,
+        OakSerializer<V> valueSerializer, ValueUtils valueOperator) {
         this.entriesLowThreshold = (int) (chunk.getMaxItems() * LOW_THRESHOLD);
         this.maxRangeToAppend = (int) (chunk.getMaxItems() * APPEND_THRESHOLD);
         this.maxAfterMergeItems = (int) (chunk.getMaxItems() * MAX_AFTER_MERGE_PART);
-        this.offHeap = offHeap;
         this.memoryManager = memoryManager;
         nextToEngage = new AtomicReference<>(chunk);
         this.first = chunk;
@@ -113,7 +111,6 @@ class Rebalancer<K, V> {
      */
     boolean createNewChunks() {
 
-        assert offHeap;
         if (this.newChunks.get() != null) {
             return false; // this was done by another thread already
         }
@@ -133,7 +130,7 @@ class Rebalancer<K, V> {
         while (true) {
             ei = currNewChunk.copyPartNoKeys(currFrozen, ei, entriesLowThreshold);
             // if completed reading curr frozen chunk
-            if (ei == Chunk.NONE) {
+            if (ei == EntrySet.NONE_NEXT) {
                 if (!iterFrozen.hasNext()) {
                     break;
                 }
@@ -155,7 +152,7 @@ class Rebalancer<K, V> {
                     // here we create a new on-heap minimal key for the second new chunk,
                     // created by the split. The new min key is on-heap copy of the one off-heap
                     // We need to use slice() method here as we want new object to be created
-                    ByteBuffer bb = currFrozen.readKey(ei).slice();
+                    ByteBuffer bb = currFrozen.readKeyFromEntryIndex(ei).slice();
                     int remaining = bb.remaining();
                     int position = bb.position();
                     ByteBuffer newMinKey = ByteBuffer.allocate(remaining);

--- a/core/src/main/java/com/oath/oak/Rebalancer.java
+++ b/core/src/main/java/com/oath/oak/Rebalancer.java
@@ -130,7 +130,7 @@ class Rebalancer<K, V> {
         while (true) {
             ei = currNewChunk.copyPartNoKeys(currFrozen, ei, entriesLowThreshold);
             // if completed reading curr frozen chunk
-            if (ei == EntrySet.NONE_NEXT) {
+            if (ei == Chunk.NONE_NEXT) {
                 if (!iterFrozen.hasNext()) {
                     break;
                 }

--- a/core/src/main/java/com/oath/oak/Slice.java
+++ b/core/src/main/java/com/oath/oak/Slice.java
@@ -13,6 +13,8 @@ import java.nio.ByteBuffer;
 public class Slice {
     private final int blockID;
     private final ByteBuffer buffer;
+    // version with which this slice was allocated, if slice is not a result of a new creation the version can be invalid
+    private int version;
     // This field is only used for sanity checks purposes and it should not be used, nor changed.
     private final int originalPosition;
 
@@ -20,6 +22,7 @@ public class Slice {
         this.blockID = blockID;
         this.buffer = buffer;
         this.originalPosition = buffer.position();
+        this.version = ValueUtilsImpl.INVALID_VERSION;
     }
 
     Slice(int blockID, int position, int length, MemoryManager memoryManager) {
@@ -41,4 +44,8 @@ public class Slice {
     boolean validatePosition() {
         return originalPosition == buffer.position();
     }
+
+    void setVersion(int version) {this.version = version;}
+
+    int getVersion() { return version; }
 }

--- a/core/src/main/java/com/oath/oak/Slice.java
+++ b/core/src/main/java/com/oath/oak/Slice.java
@@ -45,6 +45,8 @@ public class Slice {
         return originalPosition == buffer.position();
     }
 
+    int getOriginalPosition() { return originalPosition; }
+
     void setVersion(int version) {this.version = version;}
 
     int getVersion() { return version; }

--- a/core/src/main/java/com/oath/oak/ValueUtils.java
+++ b/core/src/main/java/com/oath/oak/ValueUtils.java
@@ -122,7 +122,14 @@ public interface ValueUtils {
      * May also set other members in the header to their default values.
      * @param s the value Slice (including the header), includes the version
      */
-    void initHeader(Slice s) ;
+    void initHeader(Slice s);
+
+    /**
+     * Initializing the header version and lock to be locked.
+     * May also set other members in the header to their default values.
+     * @param s the value Slice (including the header), includes the version
+     */
+    void initLockedHeader(Slice s) ;
 
     /* ==================== More complex methods on off-heap values ==================== */
 
@@ -143,11 +150,11 @@ public interface ValueUtils {
     <T> Result<T> transform(Slice s, Function<ByteBuffer, T> transformer, int version);
 
     /**
-     * @see #exchange(Chunk, Chunk.LookUp, Object, Function, OakSerializer, MemoryManager)
+     * @see #exchange(Chunk, EntrySet.LookUp, Object, Function, OakSerializer, MemoryManager, InternalOakMap)
      * Does not return the value previously written off-heap
      */
-    <V> ValueResult put(Chunk<?, V> chunk, Chunk.LookUp lookUp, V newVal, OakSerializer<V> serializer,
-                        MemoryManager memoryManager);
+    <V> ValueResult put(Chunk<?, V> chunk, EntrySet.LookUp lookUp, V newVal, OakSerializer<V> serializer,
+        MemoryManager memoryManager, InternalOakMap internalOakMap);
 
     /**
      * @param s        the value Slice (including the header)
@@ -182,13 +189,14 @@ public interface ValueUtils {
      * {@code chuck} is used iff {@code newValue} takes more space than the old value does, meaning it has to move.
      * If the value moves, the old slice is marked as moved and freed.
      *
+     * @param <V>                         the type of the value
      * @param chunk                       the chunk with the entry to which the value is linked to
      * @param lookUp                      has the Slice of the value and the entry index
      * @param value                       the new value to write
      * @param valueDeserializeTransformer used to read the previous value
      * @param serializer                  value serializer to write {@code newValue}
      * @param memoryManager               the memory manager to free a slice with is not needed after the value moved
-     * @param <V>                         the type of the value
+     * @param internalOakMap
      * @return {@code TRUE} if the value was written off-heap successfully
      * {@code FALSE} if the value is deleted (cannot be overwritten)
      * {@code RETRY} if the value was moved, if the chuck is frozen/released (prevents the moving of the value), or
@@ -196,18 +204,19 @@ public interface ValueUtils {
      * Along side the flag of the result, in case the exchange succeeded, it also returns the value that
      * was written before the exchange.
      */
-    <V> Result<V> exchange(Chunk<?, V> chunk, Chunk.LookUp lookUp, V value,
-                           Function<ByteBuffer, V> valueDeserializeTransformer, OakSerializer<V> serializer,
-                           MemoryManager memoryManager);
+    <V> Result<V> exchange(Chunk<?, V> chunk, EntrySet.LookUp lookUp, V value, Function<ByteBuffer, V> valueDeserializeTransformer, OakSerializer<V> serializer,
+        MemoryManager memoryManager, InternalOakMap internalOakMap);
 
     /**
      * @param expected the old value to which we compare the current value
+     * @param internalOakMap
      * @return {@code TRUE} if the exchange went successfully
      * {@code FAILURE} if the value is deleted or if the actual value referenced in {@code lookUp} does not equal to
      * {@code expected}
      * {@code RETRY} for the same reasons as exchange
-     * @see #exchange(Chunk, Chunk.LookUp, Object, Function, OakSerializer, MemoryManager)
+     * @see #exchange(Chunk, EntrySet.LookUp, Object, Function, OakSerializer, MemoryManager, InternalOakMap)
      */
-    <V> ValueResult compareExchange(Chunk<?, V> chunk, Chunk.LookUp lookUp, V expected, V value, Function<ByteBuffer,
-            V> valueDeserializeTransformer, OakSerializer<V> serializer, MemoryManager memoryManager);
+    <V> ValueResult compareExchange(Chunk<?, V> chunk, EntrySet.LookUp lookUp, V expected, V value,
+        Function<ByteBuffer, V> valueDeserializeTransformer, OakSerializer<V> serializer,
+        MemoryManager memoryManager, InternalOakMap internalOakMap);
 }

--- a/core/src/main/java/com/oath/oak/ValueUtils.java
+++ b/core/src/main/java/com/oath/oak/ValueUtils.java
@@ -120,10 +120,9 @@ public interface ValueUtils {
     /**
      * Initializing the header version.
      * May also set other members in the header to their default values.
-     * @param s the value Slice (including the header)
-     * @param version the new version
+     * @param s the value Slice (including the header), includes the version
      */
-    void initHeader(Slice s, int version) ;
+    void initHeader(Slice s) ;
 
     /* ==================== More complex methods on off-heap values ==================== */
 

--- a/core/src/main/java/com/oath/oak/ValueUtilsImpl.java
+++ b/core/src/main/java/com/oath/oak/ValueUtilsImpl.java
@@ -91,7 +91,7 @@ public class ValueUtilsImpl implements ValueUtils {
         memoryManager.releaseSlice(s);
         int valueLength = capacity + getHeaderSize();
         s = memoryManager.allocateSlice(valueLength, MemoryManager.Allocate.VALUE);
-        initHeader(s, memoryManager.getCurrentVersion(), LOCKED);
+        initHeader(s, LOCKED);
         boolean ret;
         ret = chunk.casEntriesArrayLong(lookUp.entryIndex, Chunk.OFFSET.VALUE_REFERENCE, lookUp.valueReference,
                 Chunk.makeReference(s, valueLength));
@@ -329,8 +329,8 @@ public class ValueUtilsImpl implements ValueUtils {
         return getInt(s, 0);
     }
 
-    private void setVersion(Slice s, int version) {
-        putInt(s, 0, version);
+    private void setVersion(Slice s) {
+        putInt(s, 0, s.getVersion());
     }
 
     private int getLockState(Slice s) {
@@ -342,12 +342,12 @@ public class ValueUtilsImpl implements ValueUtils {
     }
 
     @Override
-    public void initHeader(Slice s, int version) {
-        initHeader(s, version, FREE);
+    public void initHeader(Slice s) {
+        initHeader(s, FREE);
     }
 
-    private void initHeader(Slice s, int version, ValueUtilsImpl.LockStates state) {
-        setVersion(s, version);
+    private void initHeader(Slice s, ValueUtilsImpl.LockStates state) {
+        setVersion(s);
         setLockState(s, state);
     }
 

--- a/core/src/main/java/com/oath/oak/ValueUtilsImpl.java
+++ b/core/src/main/java/com/oath/oak/ValueUtilsImpl.java
@@ -100,13 +100,15 @@ public class ValueUtilsImpl implements ValueUtils {
         Chunk<?, V> chunk, EntrySet.LookUp lookUp, MemoryManager memoryManager,
         InternalOakMap internalOakMap, V newVal) {
 
-        Slice oldSlice = lookUp.valueSlice;
+        Slice oldSlice = lookUp.valueSlice.duplicate();
         setLockState(oldSlice, MOVED);
+
         Slice newSlice = internalOakMap.overwriteExistingValueForMove(lookUp, newVal, chunk);
         if (newSlice == null) {
             // rebalance was needed or the entry was updated by someone else, need to retry
             return null;
         }
+
         memoryManager.releaseSlice(oldSlice);
         return newSlice;
     }

--- a/core/src/main/java/com/oath/oak/ValueUtilsImpl.java
+++ b/core/src/main/java/com/oath/oak/ValueUtilsImpl.java
@@ -136,8 +136,6 @@ public class ValueUtilsImpl implements ValueUtils {
             // this thread can read from it.
             // read the old value (the slice is not reclaimed yet)
             V v = transformer != null ? transformer.apply(getValueByteBufferNoHeader(s).asReadOnlyBuffer()) : null;
-            // release the slice
-            memoryManager.releaseSlice(s);
             // return TRUE with the old value
             return Result.withValue(v);
         } else {

--- a/core/src/test/java/com/oath/oak/ValueUtilsSimpleTest.java
+++ b/core/src/test/java/com/oath/oak/ValueUtilsSimpleTest.java
@@ -22,7 +22,7 @@ public class ValueUtilsSimpleTest {
         NovaManager novaManager = new NovaManager(new OakNativeMemoryAllocator(128));
         s = novaManager.allocateSlice(16, MemoryManager.Allocate.VALUE);
         s.getByteBuffer().putInt(s.getByteBuffer().position(), 1);
-        valueOperator.initHeader(s, novaManager.getCurrentVersion());
+        valueOperator.initHeader(s);
     }
 
     @Test

--- a/core/src/test/java/com/oath/oak/ValueUtilsTest.java
+++ b/core/src/test/java/com/oath/oak/ValueUtilsTest.java
@@ -22,7 +22,7 @@ public class ValueUtilsTest {
         novaManager = new NovaManager(new OakNativeMemoryAllocator(128));
         s = novaManager.allocateSlice(20, MemoryManager.Allocate.VALUE);
         putInt(0, 1);
-        valueOperator.initHeader(s, novaManager.getCurrentVersion());
+        valueOperator.initHeader(s);
     }
 
     private void putInt(int index, int value) {

--- a/core/src/test/java/com/oath/oak/ValueUtilsTest.java
+++ b/core/src/test/java/com/oath/oak/ValueUtilsTest.java
@@ -129,7 +129,8 @@ public class ValueUtilsTest {
 
     @Test
     public void putWithNoResizeTest() {
-        Chunk.LookUp lookUp = new Chunk.LookUp(s, 0, 0, 1);
+        EntrySet.LookUp lookUp = new EntrySet.LookUp(
+            s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
         Random random = new Random();
         int[] randomValues = new int[3];
         for (int i = 0; i < randomValues.length; i++) {
@@ -152,7 +153,7 @@ public class ValueUtilsTest {
             public int calculateSize(Integer object) {
                 return 0;
             }
-        }, novaManager));
+        }, novaManager, null));
         assertEquals(randomValues[0], getInt(8));
         assertEquals(randomValues[1], getInt(12));
         assertEquals(randomValues[2], getInt(16));
@@ -160,7 +161,8 @@ public class ValueUtilsTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void putUpperBoundTest() {
-        Chunk.LookUp lookUp = new Chunk.LookUp(s, 0, 0, 1);
+        EntrySet.LookUp lookUp = new EntrySet.LookUp(
+            s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
         valueOperator.put(null, lookUp, 5, new OakSerializer<Integer>() {
             @Override
             public void serialize(Integer object, ByteBuffer targetBuffer) {
@@ -176,12 +178,13 @@ public class ValueUtilsTest {
             public int calculateSize(Integer object) {
                 return 0;
             }
-        }, novaManager);
+        }, novaManager, null);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void putLowerBoundTest() {
-        Chunk.LookUp lookUp = new Chunk.LookUp(s, 0, 0, 1);
+        EntrySet.LookUp lookUp = new EntrySet.LookUp(
+            s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
         valueOperator.put(null, lookUp, 5, new OakSerializer<Integer>() {
             @Override
             public void serialize(Integer object, ByteBuffer targetBuffer) {
@@ -197,12 +200,13 @@ public class ValueUtilsTest {
             public int calculateSize(Integer object) {
                 return 0;
             }
-        }, novaManager);
+        }, novaManager, null);
     }
 
     @Test
     public void cannotPutReadLockedTest() throws InterruptedException {
-        Chunk.LookUp lookUp = new Chunk.LookUp(s, 0, 0, 1);
+        EntrySet.LookUp lookUp = new
+            EntrySet.LookUp(s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
         CyclicBarrier barrier = new CyclicBarrier(2);
         Random random = new Random();
         int[] randomValues = new int[3];
@@ -232,7 +236,7 @@ public class ValueUtilsTest {
                 public int calculateSize(Integer object) {
                     return 0;
                 }
-            }, novaManager);
+            }, novaManager, null);
         });
         valueOperator.lockRead(s, 1);
         putter.start();
@@ -252,7 +256,8 @@ public class ValueUtilsTest {
 
     @Test
     public void cannotPutWriteLockedTest() throws InterruptedException {
-        Chunk.LookUp lookUp = new Chunk.LookUp(s, 0, 0, 1);
+        EntrySet.LookUp lookUp =
+            new EntrySet.LookUp(s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
         CyclicBarrier barrier = new CyclicBarrier(2);
         Random random = new Random();
         int[] randomValues = new int[3];
@@ -285,7 +290,7 @@ public class ValueUtilsTest {
                 public int calculateSize(Integer object) {
                     return 0;
                 }
-            }, novaManager);
+            }, novaManager, null);
         });
         valueOperator.lockWrite(s, 1);
         putter.start();
@@ -305,14 +310,14 @@ public class ValueUtilsTest {
     @Test
     public void cannotPutInDeletedValueTest() {
         valueOperator.deleteValue(s, 1);
-        Chunk.LookUp lookUp = new Chunk.LookUp(s, 0, 0, 1);
-        assertEquals(FALSE, valueOperator.put(null, lookUp, null, null, novaManager));
+        EntrySet.LookUp lookUp = new EntrySet.LookUp(s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
+        assertEquals(FALSE, valueOperator.put(null, lookUp, null, null, novaManager, null));
     }
 
     @Test
     public void cannotPutToValueOfDifferentVersionTest() {
-        Chunk.LookUp lookUp = new Chunk.LookUp(s, 0, 0, 2);
-        assertEquals(RETRY, valueOperator.put(null, lookUp, null, null, novaManager));
+        EntrySet.LookUp lookUp = new EntrySet.LookUp(s, 0, 0, 2, EntrySet.INVALID_KEY_REFERENCE);
+        assertEquals(RETRY, valueOperator.put(null, lookUp, null, null, novaManager, null));
     }
 
     @Test

--- a/core/src/test/java/com/oath/oak/ValueUtilsTest.java
+++ b/core/src/test/java/com/oath/oak/ValueUtilsTest.java
@@ -130,7 +130,7 @@ public class ValueUtilsTest {
     @Test
     public void putWithNoResizeTest() {
         EntrySet.LookUp lookUp = new EntrySet.LookUp(
-            s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
+            s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE, false);
         Random random = new Random();
         int[] randomValues = new int[3];
         for (int i = 0; i < randomValues.length; i++) {
@@ -162,7 +162,7 @@ public class ValueUtilsTest {
     @Test(expected = IndexOutOfBoundsException.class)
     public void putUpperBoundTest() {
         EntrySet.LookUp lookUp = new EntrySet.LookUp(
-            s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
+            s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE, false);
         valueOperator.put(null, lookUp, 5, new OakSerializer<Integer>() {
             @Override
             public void serialize(Integer object, ByteBuffer targetBuffer) {
@@ -184,7 +184,7 @@ public class ValueUtilsTest {
     @Test(expected = IndexOutOfBoundsException.class)
     public void putLowerBoundTest() {
         EntrySet.LookUp lookUp = new EntrySet.LookUp(
-            s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
+            s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE, false);
         valueOperator.put(null, lookUp, 5, new OakSerializer<Integer>() {
             @Override
             public void serialize(Integer object, ByteBuffer targetBuffer) {
@@ -206,7 +206,7 @@ public class ValueUtilsTest {
     @Test
     public void cannotPutReadLockedTest() throws InterruptedException {
         EntrySet.LookUp lookUp = new
-            EntrySet.LookUp(s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
+            EntrySet.LookUp(s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE, false);
         CyclicBarrier barrier = new CyclicBarrier(2);
         Random random = new Random();
         int[] randomValues = new int[3];
@@ -257,7 +257,7 @@ public class ValueUtilsTest {
     @Test
     public void cannotPutWriteLockedTest() throws InterruptedException {
         EntrySet.LookUp lookUp =
-            new EntrySet.LookUp(s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
+            new EntrySet.LookUp(s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE, false);
         CyclicBarrier barrier = new CyclicBarrier(2);
         Random random = new Random();
         int[] randomValues = new int[3];
@@ -310,13 +310,15 @@ public class ValueUtilsTest {
     @Test
     public void cannotPutInDeletedValueTest() {
         valueOperator.deleteValue(s, 1);
-        EntrySet.LookUp lookUp = new EntrySet.LookUp(s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE);
+        EntrySet.LookUp lookUp = new EntrySet.LookUp(s, 0, 0, 1, EntrySet.INVALID_KEY_REFERENCE,
+            false);
         assertEquals(FALSE, valueOperator.put(null, lookUp, null, null, novaManager, null));
     }
 
     @Test
     public void cannotPutToValueOfDifferentVersionTest() {
-        EntrySet.LookUp lookUp = new EntrySet.LookUp(s, 0, 0, 2, EntrySet.INVALID_KEY_REFERENCE);
+        EntrySet.LookUp lookUp = new EntrySet.LookUp(s, 0, 0, 2, EntrySet.INVALID_KEY_REFERENCE,
+            false);
         assertEquals(RETRY, valueOperator.put(null, lookUp, null, null, novaManager, null));
     }
 


### PR DESCRIPTION
This PR tries to encapsulate all off-heap and memory management out of Chunk to EntrySet. The code is not final and debugging effort is to be continued.
This version of EntrySet refactoring is not yet ready to be committed to Oak, just to start the code review. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
