### PR TITLE
BUGFIX: buffer limit set incorrectly in OakRKeyBuffer.getByteBuffer()

### DIFF
--- a/core/src/main/java/com/oath/oak/NativeAllocator/BlocksPool.java
+++ b/core/src/main/java/com/oath/oak/NativeAllocator/BlocksPool.java
@@ -21,7 +21,7 @@ class BlocksPool implements BlocksProvider, Closeable {
     private final ConcurrentLinkedQueue<Block> blocks = new ConcurrentLinkedQueue<>();
 
     // TODO change BLOCK_SIZE and NUMBER_OF_BLOCKS to be pre-configurable
-    private static final int BLOCK_SIZE = 256 * 1024 * 1024; // currently 256MB, the one block size
+    static final int BLOCK_SIZE = 256 * 1024 * 1024; // currently 256MB, the one block size
     // Number of memory blocks to be pre-allocated (currently gives us 2GB). When it is not enough,
     // another half such amount of memory (1GB) will be allocated at once.
     private final static int NUMBER_OF_BLOCKS = 10;
@@ -57,6 +57,9 @@ class BlocksPool implements BlocksProvider, Closeable {
     // used only in OakNativeMemoryAllocatorTest.java
     static void setBlockSize(int blockSize) {
         synchronized (BlocksPool.class) { // can be easily changed to lock-free
+            if (instance != null) {
+                instance.close();
+            }
             instance = new BlocksPool(blockSize);
         }
     }

--- a/core/src/main/java/com/oath/oak/OakRKeyBuffer.java
+++ b/core/src/main/java/com/oath/oak/OakRKeyBuffer.java
@@ -130,8 +130,8 @@ public class OakRKeyBuffer implements OakRBuffer, OakUnsafeDirectBuffer {
     @Override
     public ByteBuffer getByteBuffer() {
         ByteBuffer buff = getTemporaryPerThreadByteBuffer().asReadOnlyBuffer();
-        buff.position(headerSize + position);
-        buff.limit(headerSize + position + length);
+        buff.position(position + headerSize);
+        buff.limit(position + length);
         return buff.slice();
     }
 
@@ -149,6 +149,6 @@ public class OakRKeyBuffer implements OakRBuffer, OakUnsafeDirectBuffer {
     public long getAddress() {
         ByteBuffer buff = getTemporaryPerThreadByteBuffer();
         long address = ((DirectBuffer) buff).address();
-        return address + headerSize + position;
+        return address + position + headerSize;
     }
 }

--- a/core/src/main/java/com/oath/oak/OakRKeyBuffer.java
+++ b/core/src/main/java/com/oath/oak/OakRKeyBuffer.java
@@ -133,7 +133,7 @@ public class OakRKeyBuffer implements OakRBuffer, OakUnsafeDirectBuffer {
     public ByteBuffer getByteBuffer() {
         ByteBuffer buff = getTemporaryPerThreadByteBuffer().asReadOnlyBuffer();
         buff.position(position + headerSize);
-        buff.limit(position + length);
+        // The buffer's limit was set to the correct position by getTemporaryPerThreadByteBuffer()
         return buff.slice();
     }
 

--- a/core/src/main/java/com/oath/oak/OakRKeyBuffer.java
+++ b/core/src/main/java/com/oath/oak/OakRKeyBuffer.java
@@ -45,6 +45,8 @@ public class OakRKeyBuffer implements OakRBuffer, OakUnsafeDirectBuffer {
     void setReference(int blockID, int position, int length) {
         this.blockID = blockID;
         this.position = position;
+        // length includes the header size.
+        // The user's data length is: length - headerSize
         this.length = length;
     }
 
@@ -58,7 +60,7 @@ public class OakRKeyBuffer implements OakRBuffer, OakUnsafeDirectBuffer {
 
     @Override
     public int capacity() {
-        return getTemporaryPerThreadByteBuffer().capacity();
+        return getTemporaryPerThreadByteBuffer().capacity() - headerSize;
     }
 
     @Override

--- a/core/src/test/java/com/oath/oak/NativeAllocator/OakNativeMemoryAllocatorTest.java
+++ b/core/src/test/java/com/oath/oak/NativeAllocator/OakNativeMemoryAllocatorTest.java
@@ -15,6 +15,7 @@ import com.oath.oak.OakMap;
 import com.oath.oak.OakMapBuilder;
 import com.oath.oak.OakOutOfMemoryException;
 import com.oath.oak.OakSerializer;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -130,6 +131,11 @@ public class OakNativeMemoryAllocatorTest {
     @Before
     public void init() {
         BlocksPool.setBlockSize(8 * 1024 * 1024);
+    }
+
+    @After
+    public void tearDown() {
+        BlocksPool.setBlockSize(BlocksPool.BLOCK_SIZE);
     }
 
     @Test


### PR DESCRIPTION
* In addition, add teadDown() function to OakNativeMemoryAllocatorTest to revert the BlocksPool size.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
