### PR TITLE
Fix synchrobench class names issue

### DIFF
--- a/benchmarks/synchrobench/run.sh
+++ b/benchmarks/synchrobench/run.sh
@@ -53,7 +53,7 @@ declare -A scenarios=(
 
 
 # Oak vs JavaSkipList
-benchClassPrefix="com.oath.oak.synchrobench.maps"
+benchClassPrefix="com.oath.oak"
 benchs="JavaSkipListMap OakMyBufferMap OffHeapList"
 
 summary="${output}/summary.csv"

--- a/benchmarks/synchrobench/src/main/java/com/oath/oak/JavaSkipListMap.java
+++ b/benchmarks/synchrobench/src/main/java/com/oath/oak/JavaSkipListMap.java
@@ -1,6 +1,8 @@
-package com.oath.oak.synchrobench.maps;
+package com.oath.oak;
 
 import com.oath.oak.synchrobench.contention.abstractions.CompositionalOakMap;
+import com.oath.oak.synchrobench.MyBuffer;
+
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentSkipListMap;
 

--- a/benchmarks/synchrobench/src/main/java/com/oath/oak/OakMyBufferMap.java
+++ b/benchmarks/synchrobench/src/main/java/com/oath/oak/OakMyBufferMap.java
@@ -3,7 +3,7 @@ package com.oath.oak;
 
 import com.oath.oak.synchrobench.contention.abstractions.CompositionalOakMap;
 import com.oath.oak.synchrobench.contention.benchmark.Parameters;
-import com.oath.oak.synchrobench.maps.MyBuffer;
+import com.oath.oak.synchrobench.MyBuffer;
 
 import java.util.Iterator;
 

--- a/benchmarks/synchrobench/src/main/java/com/oath/oak/OffHeapList.java
+++ b/benchmarks/synchrobench/src/main/java/com/oath/oak/OffHeapList.java
@@ -2,7 +2,7 @@ package com.oath.oak;
 
 import com.oath.oak.synchrobench.contention.abstractions.CompositionalOakMap;
 import com.oath.oak.synchrobench.contention.benchmark.Parameters;
-import com.oath.oak.synchrobench.maps.MyBuffer;
+import com.oath.oak.synchrobench.MyBuffer;
 
 import java.nio.ByteBuffer;
 import java.util.Comparator;

--- a/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/MyBuffer.java
+++ b/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/MyBuffer.java
@@ -1,4 +1,4 @@
-package com.oath.oak.synchrobench.maps;
+package com.oath.oak.synchrobench;
 
 
 import com.oath.oak.OakComparator;

--- a/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/contention/benchmark/Test.java
+++ b/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/contention/benchmark/Test.java
@@ -4,7 +4,7 @@ import com.oath.oak.OakMyBufferMap;
 import com.oath.oak.synchrobench.contention.abstractions.CompositionalMap;
 import com.oath.oak.synchrobench.contention.abstractions.CompositionalOakMap;
 import com.oath.oak.synchrobench.contention.abstractions.MaintenanceAlg;
-import com.oath.oak.synchrobench.maps.MyBuffer;
+import com.oath.oak.synchrobench.MyBuffer;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;

--- a/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/contention/benchmark/ThreadLoopOak.java
+++ b/benchmarks/synchrobench/src/main/java/com/oath/oak/synchrobench/contention/benchmark/ThreadLoopOak.java
@@ -2,7 +2,7 @@ package com.oath.oak.synchrobench.contention.benchmark;
 
 
 import com.oath.oak.synchrobench.contention.abstractions.CompositionalOakMap;
-import com.oath.oak.synchrobench.maps.MyBuffer;
+import com.oath.oak.synchrobench.MyBuffer;
 
 import java.lang.reflect.Method;
 import java.util.Random;


### PR DESCRIPTION
Moved all maps implementations in the synchrobench module to `com.oath.oak` package and updated the `run.sh` script accordingly.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
