### PR TITLE
Fix: make the entry's value be marked as deleted by delete thread

### DIFF
--- a/core/src/main/java/com/oath/oak/Chunk.java
+++ b/core/src/main/java/com/oath/oak/Chunk.java
@@ -195,12 +195,11 @@ class Chunk<K, V> {
      * successful {@code putIfAbsent}).
      *
      * @param lookUp - holds the entry to change, the old value reference to CAS out, and the current value version.
-     * @param ongoingDeletion - true if this is the thread performing the deletion that must be finished
      * @return {@code true} if a rebalance is needed
      */
-    boolean finalizeDeletion(EntrySet.LookUp lookUp, boolean ongoingDeletion) {
+    boolean finalizeDeletion(EntrySet.LookUp lookUp) {
 
-        if (!ongoingDeletion && !entrySet.isDeleteValueFinishNeeded(lookUp)) {
+        if (!entrySet.isDeleteValueFinishNeeded(lookUp)) {
             return false;
         }
         if (!publish()) {

--- a/core/src/main/java/com/oath/oak/Chunk.java
+++ b/core/src/main/java/com/oath/oak/Chunk.java
@@ -195,11 +195,12 @@ class Chunk<K, V> {
      * successful {@code putIfAbsent}).
      *
      * @param lookUp - holds the entry to change, the old value reference to CAS out, and the current value version.
+     * @param ongoingDeletion - true if this is the thread performing the deletion that must be finished
      * @return {@code true} if a rebalance is needed
      */
-    boolean finalizeDeletion(EntrySet.LookUp lookUp) {
+    boolean finalizeDeletion(EntrySet.LookUp lookUp, boolean ongoingDeletion) {
 
-        if (!entrySet.isDeleteValueFinishNeeded(lookUp)) {
+        if (!ongoingDeletion && !entrySet.isDeleteValueFinishNeeded(lookUp)) {
             return false;
         }
         if (!publish()) {

--- a/core/src/main/java/com/oath/oak/EntrySet.java
+++ b/core/src/main/java/com/oath/oak/EntrySet.java
@@ -911,7 +911,7 @@ class EntrySet<K, V> {
         // Scenario: this value space is allocated once again and assigned into the same entry,
         // while this thread is sleeping. So later a valid value reference is CASed to invalid.
         // In order to not allow this scenario happen we must release the
-        // value's off-heap slice to memory manager only after deleteValueFinish is called.
+        // value's off-heap slice to memory manager only after deleteValueFinish is done.
         casEntriesArrayLong(indIdx, OFFSET.VALUE_REFERENCE,
             lookUp.valueReference, INVALID_VALUE_REFERENCE);
         if (casEntriesArrayInt(indIdx, OFFSET.VALUE_VERSION, version, -version)) {

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -340,7 +340,7 @@ class InternalOakMap<K, V> {
 
     private boolean finalizeDeletion(Chunk<K, V> c, EntrySet.LookUp lookUp) {
         if (lookUp != null) {
-            if (c.finalizeDeletion(lookUp)) {
+            if (c.finalizeDeletion(lookUp, false)) {
                 rebalance(c);
                 return true;
             }
@@ -680,7 +680,7 @@ class InternalOakMap<K, V> {
                 // then the old value is saved in v. Otherwise v is (correctly) null
                 return transformer == null ? Result.withFlag(logicallyDeleted ? TRUE : FALSE) : Result.withValue(v);
             } else if (lookUp.valueSlice == null) {
-                if (!c.finalizeDeletion(lookUp)) {
+                if (!c.finalizeDeletion(lookUp, false)) {
                     return transformer == null ? Result.withFlag(logicallyDeleted ? TRUE : FALSE) : Result.withValue(v);
                 }
                 rebalance(c);
@@ -714,7 +714,7 @@ class InternalOakMap<K, V> {
             assert lookUp.valueReference != EntrySet.INVALID_VALUE_REFERENCE;
 
             // publish
-            if (c.finalizeDeletion(lookUp)) {
+            if (c.finalizeDeletion(lookUp, true)) {
                 rebalance(c);
             }
         }

--- a/core/src/main/java/com/oath/oak/InternalOakMap.java
+++ b/core/src/main/java/com/oath/oak/InternalOakMap.java
@@ -340,7 +340,7 @@ class InternalOakMap<K, V> {
 
     private boolean finalizeDeletion(Chunk<K, V> c, EntrySet.LookUp lookUp) {
         if (lookUp != null) {
-            if (c.finalizeDeletion(lookUp, false)) {
+            if (c.finalizeDeletion(lookUp)) {
                 rebalance(c);
                 return true;
             }
@@ -680,7 +680,7 @@ class InternalOakMap<K, V> {
                 // then the old value is saved in v. Otherwise v is (correctly) null
                 return transformer == null ? Result.withFlag(logicallyDeleted ? TRUE : FALSE) : Result.withValue(v);
             } else if (lookUp.valueSlice == null) {
-                if (!c.finalizeDeletion(lookUp, false)) {
+                if (!c.finalizeDeletion(lookUp)) {
                     return transformer == null ? Result.withFlag(logicallyDeleted ? TRUE : FALSE) : Result.withValue(v);
                 }
                 rebalance(c);
@@ -713,8 +713,9 @@ class InternalOakMap<K, V> {
             assert lookUp.entryIndex > 0;
             assert lookUp.valueReference != EntrySet.INVALID_VALUE_REFERENCE;
 
+            lookUp.isFinalizeDeletionNeeded = true;
             // publish
-            if (c.finalizeDeletion(lookUp, true)) {
+            if (c.finalizeDeletion(lookUp)) {
                 rebalance(c);
             }
         }

--- a/core/src/main/java/com/oath/oak/ValueUtilsImpl.java
+++ b/core/src/main/java/com/oath/oak/ValueUtilsImpl.java
@@ -142,8 +142,8 @@ class ValueUtilsImpl implements ValueUtils {
             }
             // both values match so the value is marked as deleted. No need for a CAS since a write lock is exclusive
             setLockState(s, DELETED);
-            // release the slice (no need to re-read it).
-            memoryManager.releaseSlice(s);
+            // delete the value in the entry happens next and the slice will be released as part of it
+            // slice can be released only after the entry is marked appropriately
             return Result.withValue(v);
         }
     }


### PR DESCRIPTION
The marking of the entry's value as deleted must be done before releasing the slice.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
