### PR TITLE
In order to keep the MOVED bit set, do not release the moved slices for now

### DIFF
--- a/core/src/main/java/com/oath/oak/ValueUtilsImpl.java
+++ b/core/src/main/java/com/oath/oak/ValueUtilsImpl.java
@@ -95,7 +95,8 @@ class ValueUtilsImpl implements ValueUtils {
         }
         // can not release the old slice or mark it moved, before the new one is updated!
         setLockState(oldSlice, MOVED);
-        memoryManager.releaseSlice(oldSlice);
+        // currently the slices which value was moved aren't going to be released, to keep the MOVED mark
+        // TODO: deal with the reallocation of the moved memory
         return newSlice;
     }
 


### PR DESCRIPTION
The reuse of the moved memory will be done once other aspects of the Memory Manager are fixed. This is temporary fix.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
