### PR TITLE
Fix bad key initialization in advanceStream with boundaries

### DIFF
--- a/core/src/main/java/com/yahoo/oak/InternalOakMap.java
+++ b/core/src/main/java/com/yahoo/oak/InternalOakMap.java
@@ -1243,7 +1243,7 @@ class InternalOakMap<K, V> {
                         assert validState;
                     } else {
                         // If we checked the boundary, than we already read the current key into ctx.tempKey
-                        ctx.key.copyFrom(ctx.tempKey);
+                        key.buffer.copyFrom(ctx.tempKey);
                         validState = true;
                     }
                 }


### PR DESCRIPTION
In addition, add test to cover this scenario.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
