### PR TITLE
Allow the user to choose a preferred block size

### DIFF
--- a/core/src/main/java/com/yahoo/oak/OakMapBuilder.java
+++ b/core/src/main/java/com/yahoo/oak/OakMapBuilder.java
@@ -29,6 +29,7 @@ public class OakMapBuilder<K, V> {
     private int chunkMaxItems;
     private long memoryCapacity;
     private BlockMemoryAllocator memoryAllocator;
+    private Integer preferredBlockSizeBytes;
 
     public OakMapBuilder(OakComparator<K> comparator,
                          OakSerializer<K> keySerializer, OakSerializer<V> valueSerializer, K minKey) {
@@ -41,6 +42,7 @@ public class OakMapBuilder<K, V> {
         this.chunkMaxItems = Chunk.MAX_ITEMS_DEFAULT;
         this.memoryCapacity = MAX_MEM_CAPACITY;
         this.memoryAllocator = null;
+        this.preferredBlockSizeBytes = null;
     }
 
     public OakMapBuilder<K, V> setKeySerializer(OakSerializer<K> keySerializer) {
@@ -78,7 +80,19 @@ public class OakMapBuilder<K, V> {
         return this;
     }
 
+    /**
+     * Sets the preferred block size. This only has an effect if OakMap was never instantiated before.
+     * @param preferredBlockSizeBytes the preferred block size
+     */
+    public OakMapBuilder<K, V> setPreferredBlockSize(int preferredBlockSizeBytes) {
+        this.preferredBlockSizeBytes = preferredBlockSizeBytes;
+        return this;
+    }
+
     public OakMap<K, V> build() {
+        if (preferredBlockSizeBytes != null) {
+            BlocksPool.preferBlockSize(preferredBlockSizeBytes);
+        }
 
         if (memoryAllocator == null) {
             this.memoryAllocator = new NativeMemoryAllocator(memoryCapacity);

--- a/core/src/main/java/com/yahoo/oak/OakOutOfMemoryException.java
+++ b/core/src/main/java/com/yahoo/oak/OakOutOfMemoryException.java
@@ -7,5 +7,11 @@
 package com.yahoo.oak;
 
 public class OakOutOfMemoryException extends RuntimeException {
+    public OakOutOfMemoryException() {
+        super();
+    }
 
+    public OakOutOfMemoryException(String message) {
+        super(message);
+    }
 }

--- a/core/src/main/java/com/yahoo/oak/ScopedReadBuffer.java
+++ b/core/src/main/java/com/yahoo/oak/ScopedReadBuffer.java
@@ -24,7 +24,8 @@ class ScopedReadBuffer extends Slice implements OakScopedReadBuffer, OakUnsafeDi
 
     protected int getDataOffset(int index) {
         if (index < 0 || index >= getLength()) {
-            throw new IndexOutOfBoundsException();
+            throw new IndexOutOfBoundsException(String.format("Index %s is out of bound (length: %s)",
+                    index, getLength()));
         }
         return getOffset() + index;
     }

--- a/core/src/main/java/com/yahoo/oak/Slice.java
+++ b/core/src/main/java/com/yahoo/oak/Slice.java
@@ -163,6 +163,11 @@ class Slice implements OakUnsafeDirectBuffer, Comparable<Slice> {
         return ((DirectBuffer) buffer).address() + getOffset();
     }
 
+    @Override
+    public String toString() {
+        return String.format("Slice(blockID=%d, offset=%,d, length=%,d, version=%d)", blockID, offset, length, version);
+    }
+
     /*-------------- Comparable<Slice> --------------*/
 
     /**

--- a/core/src/test/java/com/yahoo/oak/NativeMemoryAllocatorTest.java
+++ b/core/src/test/java/com/yahoo/oak/NativeMemoryAllocatorTest.java
@@ -127,7 +127,7 @@ public class NativeMemoryAllocatorTest {
 
     @After
     public void tearDown() {
-        BlocksPool.setBlockSize(BlocksPool.BLOCK_SIZE);
+        BlocksPool.setBlockSize(BlocksPool.DEFAULT_BLOCK_SIZE_BYTES);
     }
 
     @Test


### PR DESCRIPTION
BlocksPool:
- Changed static configuration to use bytes instead of #blocks
- Changed #blocks limits to be initialized at the constructor according to the preferred block size
- Changed block size to be long to allow >4GB blocks

ReferenceCodec:
- Add a constructor with size limitations instead of explicit bit offsets
- Add a validation when encoding a reference

NativeMemoryAllocator:
- Add a validation when reading the buffer

EntrySet:
- Unify the key/value encoders
- Modify reference encoding to fit the new limitations and initialize it in the constructor so we can use the actual block size.

Other:
- Implement toString() for Slice (for debugging)
- Throw more informative IndexOutOfBoundsException() in ScopedReadBuffer


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
