### PR TITLE
More benchmarks v01

### DIFF
--- a/benchmarks/synchrobench/run.sh
+++ b/benchmarks/synchrobench/run.sh
@@ -22,6 +22,7 @@ declare -A scenarios=(
   ["4e-entryStreamSet-ascend"]="--buffer -c --stream-iteration"
   ["4f-entrySet-descend"]="--buffer -c -a 100"
   ["4f-entryStreamSet-descend"]="--buffer -c -a 100 --stream-iteration"
+  ["not-random-put"]="-a 0 -u 100 --inc"
 )
 
 declare -A benchmarks=(
@@ -124,13 +125,18 @@ benchClassPrefix="com.yahoo.oak"
 ############################################################################
 # Override default arguments
 ############################################################################
-while getopts o:j:d:i:w:s:t:e:b:g:m:l:r:v opt; do
+while getopts o:j:d:i:w:s:t:e:h:b:g:m:l:r:v opt; do
   case ${opt} in
   o) output=$OPTARG ;;
   j) java=$OPTARG ;;
   d) duration=$((OPTARG * 1000)) ;;
   i) iterations=$OPTARG ;;
   w) warmup=$OPTARG ;;
+  h)
+    for bench in ${!heap_limit[*]}; do
+      heap_limit[${bench}]=$OPTARG
+    done
+    ;;
   l)
     for bench in ${!direct_limit[*]}; do
       direct_limit[${bench}]=$OPTARG

--- a/benchmarks/synchrobench/run.sh
+++ b/benchmarks/synchrobench/run.sh
@@ -22,7 +22,7 @@ declare -A scenarios=(
   ["4e-entryStreamSet-ascend"]="--buffer -c --stream-iteration"
   ["4f-entrySet-descend"]="--buffer -c -a 100"
   ["4f-entryStreamSet-descend"]="--buffer -c -a 100 --stream-iteration"
-  ["not-random-put"]="-a 0 -u 100 --inc"
+  ["not-random-put"]="-a 0 -u 100 --inc" #sequential puts, doesn't need to be part of the regression
 )
 
 declare -A benchmarks=(

--- a/benchmarks/synchrobench/src/main/java/com/yahoo/oak/OakMyBufferMap.java
+++ b/benchmarks/synchrobench/src/main/java/com/yahoo/oak/OakMyBufferMap.java
@@ -129,7 +129,7 @@ public class OakMyBufferMap<K extends MyBuffer, V extends MyBuffer> implements C
     public void clear() {
         oak.close();
 
-        ma = new NativeMemoryAllocator((long) Integer.MAX_VALUE * 32);
+        ma = new NativeMemoryAllocator(OAK_MAX_OFF_MEMORY);
         if (Parameters.detailedStats) {
             ma.collectStats();
         }

--- a/core/src/main/java/com/yahoo/oak/BlocksPool.java
+++ b/core/src/main/java/com/yahoo/oak/BlocksPool.java
@@ -40,7 +40,7 @@ final class BlocksPool implements BlocksProvider, Closeable {
     private static final long HIGH_RESERVED_SIZE_BYTES = 4L * GB;
 
     // The default size of a single memory block to be allocated at once.
-    static final int DEFAULT_BLOCK_SIZE_BYTES = 256 * (int) MB;
+    static final int DEFAULT_BLOCK_SIZE_BYTES = 128 * (int) MB;
 
     /**
      * The block size in bytes that is used by this pool.

--- a/core/src/main/java/com/yahoo/oak/BlocksPool.java
+++ b/core/src/main/java/com/yahoo/oak/BlocksPool.java
@@ -40,6 +40,8 @@ final class BlocksPool implements BlocksProvider, Closeable {
     private static final long HIGH_RESERVED_SIZE_BYTES = 4L * GB;
 
     // The default size of a single memory block to be allocated at once.
+    // This block size (currently) imposes off-heap memory limit of 128GB
+    // for all Oak instances working via NativeAllocator with this pool
     static final int DEFAULT_BLOCK_SIZE_BYTES = 128 * (int) MB;
 
     /**


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Small fixes:
Sequential put benchmark, on-heap and off-heap memory limits, decreased default block size, same allocator memory limits for all benchmark iterations


