### PR TITLE
reused identical index computation in common serializer and comparator

### DIFF
--- a/core/src/main/java/com/yahoo/oak/common/OakCommonBuildersFactory.java
+++ b/core/src/main/java/com/yahoo/oak/common/OakCommonBuildersFactory.java
@@ -52,8 +52,10 @@ public class OakCommonBuildersFactory {
 
     public static OakMapBuilder<ByteBuffer, ByteBuffer> getDefaultIntBufferBuilder(int keySize, int valueSize) {
         ByteBuffer minKey = ByteBuffer.allocate(keySize * Integer.BYTES);
+        int index = 0;
         for (int i = 0; i < keySize; i++) {
-            minKey.putInt(Integer.BYTES * i, Integer.MIN_VALUE);
+            minKey.putInt(index, Integer.MIN_VALUE);
+            index += Integer.BYTES;
         }
         minKey.position(0);
 

--- a/core/src/main/java/com/yahoo/oak/common/intbuffer/OakIntBufferComparator.java
+++ b/core/src/main/java/com/yahoo/oak/common/intbuffer/OakIntBufferComparator.java
@@ -40,9 +40,9 @@ public class OakIntBufferComparator implements OakComparator<ByteBuffer> {
     }
 
     public static int compare(ByteBuffer buff1, int pos1, int size1, ByteBuffer buff2, int pos2, int size2) {
-        int minSize = Math.min(size1, size2);
-        int offset = 0;
+        final int minSize = Math.min(size1, size2);
 
+        int offset = 0;
         for (int i = 0; i < minSize; i++) {
             int i1 = buff1.getInt(pos1 + offset);
             int i2 = buff2.getInt(pos2 + offset);

--- a/core/src/main/java/com/yahoo/oak/common/intbuffer/OakIntBufferComparator.java
+++ b/core/src/main/java/com/yahoo/oak/common/intbuffer/OakIntBufferComparator.java
@@ -41,15 +41,16 @@ public class OakIntBufferComparator implements OakComparator<ByteBuffer> {
 
     public static int compare(ByteBuffer buff1, int pos1, int size1, ByteBuffer buff2, int pos2, int size2) {
         int minSize = Math.min(size1, size2);
+        int offset = 0;
 
         for (int i = 0; i < minSize; i++) {
-            int offset = Integer.BYTES * i;
             int i1 = buff1.getInt(pos1 + offset);
             int i2 = buff2.getInt(pos2 + offset);
             int compare = Integer.compare(i1, i2);
             if (compare != 0) {
                 return compare;
             }
+            offset += Integer.BYTES;
         }
 
         return Integer.compare(size1, size2);

--- a/core/src/main/java/com/yahoo/oak/common/intbuffer/OakIntBufferComparator.java
+++ b/core/src/main/java/com/yahoo/oak/common/intbuffer/OakIntBufferComparator.java
@@ -43,8 +43,9 @@ public class OakIntBufferComparator implements OakComparator<ByteBuffer> {
         int minSize = Math.min(size1, size2);
 
         for (int i = 0; i < minSize; i++) {
-            int i1 = buff1.getInt(pos1 + Integer.BYTES * i);
-            int i2 = buff2.getInt(pos2 + Integer.BYTES * i);
+            int offset = Integer.BYTES * i;
+            int i1 = buff1.getInt(pos1 + offset);
+            int i2 = buff2.getInt(pos2 + offset);
             int compare = Integer.compare(i1, i2);
             if (compare != 0) {
                 return compare;

--- a/core/src/main/java/com/yahoo/oak/common/intbuffer/OakIntBufferSerializer.java
+++ b/core/src/main/java/com/yahoo/oak/common/intbuffer/OakIntBufferSerializer.java
@@ -48,8 +48,9 @@ public class OakIntBufferSerializer implements OakSerializer<ByteBuffer> {
 
     public static void copyBuffer(ByteBuffer src, int srcPos, int srcSize, ByteBuffer dst, int dstPos) {
         for (int i = 0; i < srcSize; i++) {
-            int data = src.getInt(srcPos + Integer.BYTES * i);
-            dst.putInt(dstPos + Integer.BYTES * i, data);
+            int offset = Integer.BYTES * i;
+            int data = src.getInt(srcPos + offset);
+            dst.putInt(dstPos + offset, data);
         }
     }
 }

--- a/core/src/main/java/com/yahoo/oak/common/intbuffer/OakIntBufferSerializer.java
+++ b/core/src/main/java/com/yahoo/oak/common/intbuffer/OakIntBufferSerializer.java
@@ -47,10 +47,11 @@ public class OakIntBufferSerializer implements OakSerializer<ByteBuffer> {
     }
 
     public static void copyBuffer(ByteBuffer src, int srcPos, int srcSize, ByteBuffer dst, int dstPos) {
+        int offset = 0;
         for (int i = 0; i < srcSize; i++) {
-            int offset = Integer.BYTES * i;
             int data = src.getInt(srcPos + offset);
             dst.putInt(dstPos + offset, data);
+            offset += Integer.BYTES;
         }
     }
 }

--- a/core/src/main/java/com/yahoo/oak/common/string/OakStringComparator.java
+++ b/core/src/main/java/com/yahoo/oak/common/string/OakStringComparator.java
@@ -23,8 +23,9 @@ public class OakStringComparator implements OakComparator<String> {
         final int minSize = Math.min(size1, size2);
 
         for (int i = 0; i < minSize; i++) {
-            char c1 = serializedKey1.getChar(Integer.BYTES + i * Character.BYTES);
-            char c2 = serializedKey2.getChar(Integer.BYTES + i * Character.BYTES);
+            int index = Integer.BYTES + i * Character.BYTES;
+            char c1 = serializedKey1.getChar(index);
+            char c2 = serializedKey2.getChar(index);
             int compare = Character.compare(c1, c2);
             if (compare != 0) {
                 return compare;

--- a/core/src/main/java/com/yahoo/oak/common/string/OakStringComparator.java
+++ b/core/src/main/java/com/yahoo/oak/common/string/OakStringComparator.java
@@ -41,8 +41,8 @@ public class OakStringComparator implements OakComparator<String> {
         final int size1 = key.length();
         final int size2 = serializedKey.getInt(0);
         final int minSize = Math.min(size1, size2);
-        int index = Integer.BYTES;
 
+        int index = Integer.BYTES;
         for (int i = 0; i < minSize; i++) {
             char c1 = key.charAt(i);
             char c2 = serializedKey.getChar(index);

--- a/core/src/main/java/com/yahoo/oak/common/string/OakStringComparator.java
+++ b/core/src/main/java/com/yahoo/oak/common/string/OakStringComparator.java
@@ -21,8 +21,8 @@ public class OakStringComparator implements OakComparator<String> {
         final int size1 = serializedKey1.getInt(0);
         final int size2 = serializedKey2.getInt(0);
         final int minSize = Math.min(size1, size2);
-        int index = Integer.BYTES;
 
+        int index = Integer.BYTES;
         for (int i = 0; i < minSize; i++) {
             char c1 = serializedKey1.getChar(index);
             char c2 = serializedKey2.getChar(index);

--- a/core/src/main/java/com/yahoo/oak/common/string/OakStringComparator.java
+++ b/core/src/main/java/com/yahoo/oak/common/string/OakStringComparator.java
@@ -21,15 +21,16 @@ public class OakStringComparator implements OakComparator<String> {
         final int size1 = serializedKey1.getInt(0);
         final int size2 = serializedKey2.getInt(0);
         final int minSize = Math.min(size1, size2);
+        int index = Integer.BYTES;
 
         for (int i = 0; i < minSize; i++) {
-            int index = Integer.BYTES + i * Character.BYTES;
             char c1 = serializedKey1.getChar(index);
             char c2 = serializedKey2.getChar(index);
             int compare = Character.compare(c1, c2);
             if (compare != 0) {
                 return compare;
             }
+            index += Character.BYTES;
         }
 
         return size1 - size2;
@@ -40,14 +41,16 @@ public class OakStringComparator implements OakComparator<String> {
         final int size1 = key.length();
         final int size2 = serializedKey.getInt(0);
         final int minSize = Math.min(size1, size2);
+        int index = Integer.BYTES;
 
         for (int i = 0; i < minSize; i++) {
             char c1 = key.charAt(i);
-            char c2 = serializedKey.getChar(Integer.BYTES + i * Character.BYTES);
+            char c2 = serializedKey.getChar(index);
             int compare = Character.compare(c1, c2);
             if (compare != 0) {
                 return compare;
             }
+            index += Character.BYTES;
         }
 
         return size1 - size2;

--- a/core/src/main/java/com/yahoo/oak/common/string/OakStringSerializer.java
+++ b/core/src/main/java/com/yahoo/oak/common/string/OakStringSerializer.java
@@ -17,9 +17,11 @@ public class OakStringSerializer implements OakSerializer<String> {
         final int size = object.length();
 
         targetBuffer.putInt(0, size);
+        int index = Integer.BYTES;
         for (int i = 0; i < object.length(); i++) {
             char c = object.charAt(i);
-            targetBuffer.putChar(Integer.BYTES + i * Character.BYTES, c);
+            targetBuffer.putChar(index, c);
+            index += Character.BYTES;
         }
     }
 
@@ -28,9 +30,11 @@ public class OakStringSerializer implements OakSerializer<String> {
         final int size = byteBuffer.getInt(0);
 
         StringBuilder object = new StringBuilder(size);
+        int index = Integer.BYTES;
         for (int i = 0; i < size; i++) {
-            char c = byteBuffer.getChar(Integer.BYTES + i * Character.BYTES);
+            char c = byteBuffer.getChar(index);
             object.append(c);
+            index += Character.BYTES;
         }
         return object.toString();
     }


### PR DESCRIPTION
reused identical index computation in common serializer and comparator in OakIntBufferComparator, OakIntBufferSerializer, and OakStringComparator.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
