### PR TITLE
Refactor `ExecutorUtils` to reduce code duplication in tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.8</version>
+                <version>2.22.2</version>
                 <configuration>
                     <argLine>
                         -XX:MaxDirectMemorySize=4g

--- a/core/src/test/java/com/yahoo/oak/ComputeTest.java
+++ b/core/src/test/java/com/yahoo/oak/ComputeTest.java
@@ -33,12 +33,12 @@ public class ComputeTest {
 
     private static int numOfEntries;
 
-    ExecutorUtils executor;
+    ExecutorUtils<Void> executor;
     private CountDownLatch latch;
 
     @Before
     public void setup() {
-        executor = new ExecutorUtils(NUM_THREADS);
+        executor = new ExecutorUtils<>(NUM_THREADS);
         latch = new CountDownLatch(1);
     }
 

--- a/core/src/test/java/com/yahoo/oak/ComputeTest.java
+++ b/core/src/test/java/com/yahoo/oak/ComputeTest.java
@@ -17,8 +17,6 @@ import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 
@@ -100,7 +98,7 @@ public class ComputeTest {
     }
 
     @Test
-    public void testMain() throws InterruptedException, TimeoutException, ExecutionException {
+    public void testMain() throws ExecutorUtils.ExecutionError {
         ByteBuffer minKey = ByteBuffer.allocate(KEY_SIZE * Integer.BYTES);
         minKey.position(0);
         for (int i = 0; i < KEY_SIZE; i++) {

--- a/core/src/test/java/com/yahoo/oak/ComputeTest.java
+++ b/core/src/test/java/com/yahoo/oak/ComputeTest.java
@@ -8,21 +8,16 @@ package com.yahoo.oak;
 
 import com.yahoo.oak.common.OakCommonBuildersFactory;
 import com.yahoo.oak.test_utils.ExecutorUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
@@ -30,23 +25,28 @@ import java.util.function.Consumer;
 public class ComputeTest {
 
     private static final int NUM_THREADS = 16;
+    private static final long TIME_LIMIT_IN_SECONDS = 60;
 
-    private static OakMap<ByteBuffer, ByteBuffer> oak;
     private static final long K = 1024;
-
     private static final int KEY_SIZE = 10;
     private static final int VAL_SIZE = Math.round(5 * K);
+
+    private static OakMap<ByteBuffer, ByteBuffer> oak;
+
     private static int numOfEntries;
-    private final long timeLimitInMs = TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
-    ExecutorService executor;
+
+    ExecutorUtils executor;
     private CountDownLatch latch;
-
-
 
     @Before
     public void setup() {
-        executor = Executors.newFixedThreadPool(NUM_THREADS);
+        executor = new ExecutorUtils(NUM_THREADS);
         latch = new CountDownLatch(1);
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
     }
 
     private static  Consumer<OakScopedWriteBuffer> computer = oakWBuffer -> {
@@ -116,10 +116,7 @@ public class ComputeTest {
 
         numOfEntries = 100;
 
-        List<Future<?>> tasks = new ArrayList<>();
-        for (int i = 0; i < NUM_THREADS; i++) {
-            tasks.add(executor.submit(new RunThreads(latch))) ;
-        }
+        executor.submitTasks(NUM_THREADS, i -> new RunThreads(latch));
 
         for (int i = 0; i < (int) Math.round(numOfEntries * 0.5); i++) {
             ByteBuffer key = ByteBuffer.allocate(KEY_SIZE * Integer.BYTES);
@@ -130,7 +127,7 @@ public class ComputeTest {
         }
 
         latch.countDown();
-        ExecutorUtils.shutdownTaskPool(executor, tasks, timeLimitInMs);
+        executor.shutdown(TIME_LIMIT_IN_SECONDS);
 
         for (int i = 0; i < numOfEntries; i++) {
             ByteBuffer key = ByteBuffer.allocate(KEY_SIZE * Integer.BYTES);

--- a/core/src/test/java/com/yahoo/oak/ConcurrentPutRemoveTest.java
+++ b/core/src/test/java/com/yahoo/oak/ConcurrentPutRemoveTest.java
@@ -18,8 +18,6 @@ import java.util.Random;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -87,7 +85,7 @@ public class ConcurrentPutRemoveTest {
 
     @Ignore
     @Test
-    public void testMain() throws InterruptedException, TimeoutException, ExecutionException, BrokenBarrierException {
+    public void testMain() throws InterruptedException, ExecutorUtils.ExecutionError, BrokenBarrierException {
         executor.submitTasks(NUM_THREADS, i -> new RunThread());
         Random r = new Random();
         for (int i = 0; i < (int) Math.round(NUM_OF_ENTRIES * 0.5); ) {

--- a/core/src/test/java/com/yahoo/oak/ConcurrentPutRemoveTest.java
+++ b/core/src/test/java/com/yahoo/oak/ConcurrentPutRemoveTest.java
@@ -30,7 +30,7 @@ public class ConcurrentPutRemoveTest {
     private static final int K = 1024;
     private static final int NUM_OF_ENTRIES = 10 * K;
 
-    private ExecutorUtils executor;
+    private ExecutorUtils<Void> executor;
     private OakMap<Integer, Integer> oak;
 
     private AtomicBoolean stop;
@@ -43,7 +43,7 @@ public class ConcurrentPutRemoveTest {
         oak = builder.build();
         barrier = new CyclicBarrier(NUM_THREADS + 1);
         stop = new AtomicBoolean(false);
-        executor = new ExecutorUtils(NUM_THREADS);
+        executor = new ExecutorUtils<>(NUM_THREADS);
         status = new AtomicInteger[NUM_OF_ENTRIES];
         for (int i = 0; i < status.length; i++) {
             status[i] = new AtomicInteger(0);

--- a/core/src/test/java/com/yahoo/oak/FillTest.java
+++ b/core/src/test/java/com/yahoo/oak/FillTest.java
@@ -9,40 +9,41 @@ package com.yahoo.oak;
 import com.yahoo.oak.common.OakCommonBuildersFactory;
 import com.yahoo.oak.common.integer.OakIntSerializer;
 import com.yahoo.oak.test_utils.ExecutorUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
 public class FillTest {
 
     private static final int NUM_THREADS = 1;
+    private static final long TIME_LIMIT_IN_SECONDS = 60;
 
-    static OakMap<Integer, Integer> oak;
     private static final long K = 1024;
-
     private static final int KEY_SIZE = 10;
     private static final int VALUE_SIZE = Math.round(5 * K);
+
     private static final int NUM_OF_ENTRIES = 100;
-    private final long timeLimitInMs = TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
+
+    static OakMap<Integer, Integer> oak;
     private  CountDownLatch latch;
-    private  ExecutorService executor;
+    private  ExecutorUtils executor;
 
     @Before
     public void setup() {
         latch = new CountDownLatch(1);
-        executor = Executors.newFixedThreadPool(NUM_THREADS);
+        executor = new ExecutorUtils(NUM_THREADS);
+    }
 
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
     }
 
     static class RunThreads implements Callable<Void> {
@@ -100,10 +101,7 @@ public class FillTest {
 
         oak = builder.build();
 
-        List<Future<?>> tasks = new ArrayList<>();
-        for (int i = 0; i < NUM_THREADS; i++) {
-            tasks.add(executor.submit(new RunThreads(latch))) ;
-        }
+        executor.submitTasks(NUM_THREADS, i -> new RunThreads(latch));
 
         for (int i = 0; i < (int) Math.round(NUM_OF_ENTRIES * 0.5); i++) {
             oak.zc().putIfAbsent(i, i);
@@ -112,8 +110,7 @@ public class FillTest {
         long startTime = System.currentTimeMillis();
 
         latch.countDown();
-
-        ExecutorUtils.shutdownTaskPool(executor, tasks, timeLimitInMs);
+        executor.shutdown(TIME_LIMIT_IN_SECONDS);
 
         long stopTime = System.currentTimeMillis();
 

--- a/core/src/test/java/com/yahoo/oak/FillTest.java
+++ b/core/src/test/java/com/yahoo/oak/FillTest.java
@@ -17,8 +17,6 @@ import org.junit.Test;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 public class FillTest {
 
@@ -92,7 +90,7 @@ public class FillTest {
     }
 
     @Test
-    public void testMain() throws InterruptedException, TimeoutException, ExecutionException {
+    public void testMain() throws ExecutorUtils.ExecutionError {
 
         OakMapBuilder<Integer, Integer> builder = OakCommonBuildersFactory.getDefaultIntBuilder()
             .setChunkMaxItems(2048)

--- a/core/src/test/java/com/yahoo/oak/FillTest.java
+++ b/core/src/test/java/com/yahoo/oak/FillTest.java
@@ -31,12 +31,12 @@ public class FillTest {
 
     static OakMap<Integer, Integer> oak;
     private  CountDownLatch latch;
-    private  ExecutorUtils executor;
+    private  ExecutorUtils<Void> executor;
 
     @Before
     public void setup() {
         latch = new CountDownLatch(1);
-        executor = new ExecutorUtils(NUM_THREADS);
+        executor = new ExecutorUtils<>(NUM_THREADS);
     }
 
     @After

--- a/core/src/test/java/com/yahoo/oak/MultiThreadComputeTest.java
+++ b/core/src/test/java/com/yahoo/oak/MultiThreadComputeTest.java
@@ -15,8 +15,6 @@ import org.junit.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 public class MultiThreadComputeTest {
@@ -135,7 +133,7 @@ public class MultiThreadComputeTest {
     }
 
     @Test
-    public void testThreadsCompute() throws InterruptedException, TimeoutException, ExecutionException {
+    public void testThreadsCompute() throws ExecutorUtils.ExecutionError {
         executor.submitTasks(NUM_THREADS, i -> new MultiThreadComputeTest.RunThreads(latch));
         latch.countDown();
         executor.shutdown(TIME_LIMIT_IN_SECONDS);

--- a/core/src/test/java/com/yahoo/oak/MultiThreadComputeTest.java
+++ b/core/src/test/java/com/yahoo/oak/MultiThreadComputeTest.java
@@ -23,7 +23,7 @@ public class MultiThreadComputeTest {
     private static final int MAX_ITEMS_PER_CHUNK = 1024;
 
     private OakMap<Integer, Integer> oak;
-    private ExecutorUtils executor;
+    private ExecutorUtils<Void> executor;
 
     private CountDownLatch latch;
     private Consumer<OakScopedWriteBuffer> computer;
@@ -35,7 +35,7 @@ public class MultiThreadComputeTest {
                 .setChunkMaxItems(MAX_ITEMS_PER_CHUNK);
         oak = builder.build();
         latch = new CountDownLatch(1);
-        executor = new ExecutorUtils(NUM_THREADS);
+        executor = new ExecutorUtils<>(NUM_THREADS);
         computer = oakWBuffer -> {
             if (oakWBuffer.getInt(0) == 0) {
                 oakWBuffer.putInt(0, 1);

--- a/core/src/test/java/com/yahoo/oak/MultiThreadComputeTest.java
+++ b/core/src/test/java/com/yahoo/oak/MultiThreadComputeTest.java
@@ -13,28 +13,23 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 public class MultiThreadComputeTest {
+    private static final int NUM_THREADS = 31;
+    private static final long TIME_LIMIT_IN_SECONDS = 60;
+    private static final int MAX_ITEMS_PER_CHUNK = 1024;
 
     private OakMap<Integer, Integer> oak;
-    private static final int NUM_THREADS = 31;
-    private ExecutorService executor;
+    private ExecutorUtils executor;
+
     private CountDownLatch latch;
     private Consumer<OakScopedWriteBuffer> computer;
     private Consumer<OakScopedWriteBuffer> emptyComputer;
-    private static final int MAX_ITEMS_PER_CHUNK = 1024;
-    private final long timeLimitInMs = TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
 
     @Before
     public void init() {
@@ -42,7 +37,7 @@ public class MultiThreadComputeTest {
                 .setChunkMaxItems(MAX_ITEMS_PER_CHUNK);
         oak = builder.build();
         latch = new CountDownLatch(1);
-        executor = Executors.newFixedThreadPool(NUM_THREADS);
+        executor = new ExecutorUtils(NUM_THREADS);
         computer = oakWBuffer -> {
             if (oakWBuffer.getInt(0) == 0) {
                 oakWBuffer.putInt(0, 1);
@@ -54,6 +49,7 @@ public class MultiThreadComputeTest {
 
     @After
     public void finish() {
+        executor.shutdownNow();
         oak.close();
     }
 
@@ -140,15 +136,9 @@ public class MultiThreadComputeTest {
 
     @Test
     public void testThreadsCompute() throws InterruptedException, TimeoutException, ExecutionException {
-
-        List<Future<?>> tasks = new ArrayList<>();
-        for (int i = 0; i < NUM_THREADS; i++) {
-            tasks.add(executor.submit(new MultiThreadComputeTest.RunThreads(latch))) ;
-        }
-
+        executor.submitTasks(NUM_THREADS, i -> new MultiThreadComputeTest.RunThreads(latch));
         latch.countDown();
-
-        ExecutorUtils.shutdownTaskPool(executor, tasks, timeLimitInMs);
+        executor.shutdown(TIME_LIMIT_IN_SECONDS);
 
         for (Integer i = 0; i < MAX_ITEMS_PER_CHUNK; i++) {
             Integer value = oak.get(i);
@@ -163,7 +153,7 @@ public class MultiThreadComputeTest {
             }
             Assert.assertEquals(i, value);
         }
-        for (Integer i = MAX_ITEMS_PER_CHUNK; i < 2 * MAX_ITEMS_PER_CHUNK; i++) {
+        for (int i = MAX_ITEMS_PER_CHUNK; i < 2 * MAX_ITEMS_PER_CHUNK; i++) {
             Integer value = oak.get(i);
             Assert.assertNull(value);
         }
@@ -171,7 +161,7 @@ public class MultiThreadComputeTest {
             Integer value = oak.get(i);
             Assert.assertEquals(i, value);
         }
-        for (Integer i = 3 * MAX_ITEMS_PER_CHUNK; i < 4 * MAX_ITEMS_PER_CHUNK; i++) {
+        for (int i = 3 * MAX_ITEMS_PER_CHUNK; i < 4 * MAX_ITEMS_PER_CHUNK; i++) {
             Integer value = oak.get(i);
             Assert.assertNull(value);
         }

--- a/core/src/test/java/com/yahoo/oak/MultiThreadRangeTest.java
+++ b/core/src/test/java/com/yahoo/oak/MultiThreadRangeTest.java
@@ -17,8 +17,6 @@ import java.util.Iterator;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 public class MultiThreadRangeTest {
 
@@ -71,7 +69,7 @@ public class MultiThreadRangeTest {
     }
 
     @Test
-    public void testRange() throws InterruptedException, TimeoutException, ExecutionException {
+    public void testRange() throws ExecutorUtils.ExecutionError {
         executor.submitTasks(NUM_THREADS, i -> new MultiThreadRangeTest.RunThreads(latch));
 
         // fill

--- a/core/src/test/java/com/yahoo/oak/MultiThreadRangeTest.java
+++ b/core/src/test/java/com/yahoo/oak/MultiThreadRangeTest.java
@@ -25,7 +25,7 @@ public class MultiThreadRangeTest {
     private static final int MAX_ITEMS_PER_CHUNK = 2048;
 
     private OakMap<Integer, Integer> oak;
-    private ExecutorUtils executor;
+    private ExecutorUtils<Void> executor;
 
     private CountDownLatch latch;
 
@@ -35,7 +35,7 @@ public class MultiThreadRangeTest {
                 .setChunkMaxItems(MAX_ITEMS_PER_CHUNK);
         oak = builder.build();
         latch = new CountDownLatch(1);
-        executor = new ExecutorUtils(NUM_THREADS);
+        executor = new ExecutorUtils<>(NUM_THREADS);
     }
 
     @After

--- a/core/src/test/java/com/yahoo/oak/MultiThreadTest.java
+++ b/core/src/test/java/com/yahoo/oak/MultiThreadTest.java
@@ -20,8 +20,6 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 public class MultiThreadTest {
@@ -156,7 +154,7 @@ public class MultiThreadTest {
     }
 
     @Test
-    public void testThreads() throws InterruptedException, TimeoutException, ExecutionException {
+    public void testThreads() throws ExecutorUtils.ExecutionError {
         executor.submitTasks(NUM_THREADS, i -> new MultiThreadTest.RunThreads(latch));
         latch.countDown();
         executor.shutdown(TIME_LIMIT_IN_SECONDS);
@@ -276,7 +274,7 @@ public class MultiThreadTest {
     }
 
     @Test
-    public void testThreadsDescend() throws InterruptedException, TimeoutException, ExecutionException {
+    public void testThreadsDescend() throws ExecutorUtils.ExecutionError {
         CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
 
         executor.submitTasks(NUM_THREADS, i -> new MultiThreadTest.RunThreadsDescend(latch, barrier));

--- a/core/src/test/java/com/yahoo/oak/MultiThreadTest.java
+++ b/core/src/test/java/com/yahoo/oak/MultiThreadTest.java
@@ -14,32 +14,27 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 public class MultiThreadTest {
 
-    private OakMap<Integer, Integer> oak;
     private static final int NUM_THREADS = 31;
-    private ExecutorService executor;
+    private static final long TIME_LIMIT_IN_SECONDS = 60;
+
+    private static final int MAX_ITEMS_PER_CHUNK = 2048;
+
+    private OakMap<Integer, Integer> oak;
+    private ExecutorUtils executor;
 
     private CountDownLatch latch;
-    private static final int MAX_ITEMS_PER_CHUNK = 2048;
-    private final long timeLimitInMs = TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
-
 
     @Before
     public void init() {
@@ -47,15 +42,16 @@ public class MultiThreadTest {
                 .setChunkMaxItems(MAX_ITEMS_PER_CHUNK);
         oak = builder.build();
         latch = new CountDownLatch(1);
-        executor = Executors.newFixedThreadPool(NUM_THREADS);
+        executor = new ExecutorUtils(NUM_THREADS);
     }
 
     @After
     public void finish() {
+        executor.shutdownNow();
         oak.close();
     }
 
-    class RunThreads implements Callable {
+    class RunThreads implements Callable<Void> {
         CountDownLatch latch;
 
         RunThreads(CountDownLatch latch) {
@@ -67,47 +63,47 @@ public class MultiThreadTest {
             latch.await();
             Integer value;
 
-            for (Integer i = 0; i < (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i++) {
+            for (int i = 0; i < (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i++) {
                 value = oak.get(i);
                 Assert.assertNull(value);
             }
-            for (Integer i = MAX_ITEMS_PER_CHUNK; i < 2 * MAX_ITEMS_PER_CHUNK; i++) {
+            for (int i = MAX_ITEMS_PER_CHUNK; i < 2 * MAX_ITEMS_PER_CHUNK; i++) {
                 oak.zc().putIfAbsent(i, i);
             }
             for (Integer i = MAX_ITEMS_PER_CHUNK; i < 2 * MAX_ITEMS_PER_CHUNK; i++) {
                 value = oak.get(i);
                 Assert.assertEquals(i, value);
             }
-            for (Integer i = 0; i < (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i++) {
+            for (int i = 0; i < (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i++) {
                 value = oak.get(i);
                 Assert.assertNull(value);
             }
-            for (Integer i = 2 * MAX_ITEMS_PER_CHUNK; i < 3 * MAX_ITEMS_PER_CHUNK; i++) {
+            for (int i = 2 * MAX_ITEMS_PER_CHUNK; i < 3 * MAX_ITEMS_PER_CHUNK; i++) {
                 oak.zc().putIfAbsent(i, i);
             }
-            for (Integer i = 2 * MAX_ITEMS_PER_CHUNK; i < 3 * MAX_ITEMS_PER_CHUNK; i++) {
+            for (int i = 2 * MAX_ITEMS_PER_CHUNK; i < 3 * MAX_ITEMS_PER_CHUNK; i++) {
                 oak.zc().remove(i);
             }
             for (Integer i = MAX_ITEMS_PER_CHUNK; i < 2 * MAX_ITEMS_PER_CHUNK; i++) {
                 value = oak.get(i);
                 Assert.assertEquals(i, value);
             }
-            for (Integer i = (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i < MAX_ITEMS_PER_CHUNK; i++) {
+            for (int i = (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i < MAX_ITEMS_PER_CHUNK; i++) {
                 oak.zc().putIfAbsent(i, i);
             }
             for (Integer i = (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i < MAX_ITEMS_PER_CHUNK; i++) {
                 value = oak.get(i);
                 Assert.assertEquals(i, value);
             }
-            for (Integer i = 3 * MAX_ITEMS_PER_CHUNK; i < 4 * MAX_ITEMS_PER_CHUNK; i++) {
+            for (int i = 3 * MAX_ITEMS_PER_CHUNK; i < 4 * MAX_ITEMS_PER_CHUNK; i++) {
                 value = oak.get(i);
                 Assert.assertNull(value);
             }
-            for (Integer i = 3 * MAX_ITEMS_PER_CHUNK; i < 4 * MAX_ITEMS_PER_CHUNK; i++) {
+            for (int i = 3 * MAX_ITEMS_PER_CHUNK; i < 4 * MAX_ITEMS_PER_CHUNK; i++) {
                 oak.zc().remove(i);
             }
 
-            Iterator valIter = oak.values().iterator();
+            Iterator<Integer> valIter = oak.values().iterator();
             Integer twiceMaxItemsPerChunk = 2 * MAX_ITEMS_PER_CHUNK;
             Integer c = (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK);
             while (valIter.hasNext() && c < twiceMaxItemsPerChunk) {
@@ -118,9 +114,9 @@ public class MultiThreadTest {
             }
             Assert.assertEquals(twiceMaxItemsPerChunk, c);
 
-            Integer from = 0;
-            Integer to = twiceMaxItemsPerChunk;
-            try (OakMap sub = oak.subMap(from, true, to, false)) {
+            int from = 0;
+            int to = twiceMaxItemsPerChunk;
+            try (OakMap<Integer, Integer> sub = oak.subMap(from, true, to, false)) {
                 valIter = sub.values().iterator();
                 c = (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK);
                 while (valIter.hasNext()) {
@@ -135,17 +131,16 @@ public class MultiThreadTest {
 
             from = 1;
             to = (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK);
-            try (OakMap sub = oak.subMap(from, true, to, false)) {
+            try (OakMap<Integer, Integer> sub = oak.subMap(from, true, to, false)) {
                 valIter = sub.values().iterator();
                 Assert.assertFalse(valIter.hasNext());
             }
             from = 4 * MAX_ITEMS_PER_CHUNK;
             to = 5 * MAX_ITEMS_PER_CHUNK;
-            try (OakMap sub = oak.subMap(from, true, to, false)) {
+            try (OakMap<Integer, Integer> sub = oak.subMap(from, true, to, false)) {
                 valIter = sub.values().iterator();
                 Assert.assertFalse(valIter.hasNext());
             }
-
 
             for (int i = (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i < MAX_ITEMS_PER_CHUNK; i++) {
                 ByteBuffer bb = ByteBuffer.allocate(4);
@@ -162,23 +157,19 @@ public class MultiThreadTest {
 
     @Test
     public void testThreads() throws InterruptedException, TimeoutException, ExecutionException {
-
-        List<Future<?>> tasks = new ArrayList<>();
-        for (int i = 0; i < NUM_THREADS; i++) {
-            tasks.add(executor.submit(new MultiThreadTest.RunThreads(latch))) ;
-        }
+        executor.submitTasks(NUM_THREADS, i -> new MultiThreadTest.RunThreads(latch));
         latch.countDown();
-        ExecutorUtils.shutdownTaskPool(executor, tasks, timeLimitInMs);
+        executor.shutdown(TIME_LIMIT_IN_SECONDS);
 
         for (Integer i = (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i < 2 * MAX_ITEMS_PER_CHUNK; i++) {
             Integer value = oak.get(i);
             Assert.assertEquals(i, value);
         }
-        for (Integer i = 2 * MAX_ITEMS_PER_CHUNK; i < 4 * MAX_ITEMS_PER_CHUNK; i++) {
+        for (int i = 2 * MAX_ITEMS_PER_CHUNK; i < 4 * MAX_ITEMS_PER_CHUNK; i++) {
             Integer value = oak.get(i);
             Assert.assertNull(value);
         }
-        for (Integer i = 0; i < (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i++) {
+        for (int i = 0; i < (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK); i++) {
             Integer value = oak.get(i);
             Assert.assertNull(value);
         }
@@ -288,13 +279,9 @@ public class MultiThreadTest {
     public void testThreadsDescend() throws InterruptedException, TimeoutException, ExecutionException {
         CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
 
-        List<Future<?>> tasks = new ArrayList<>();
-        for (int i = 0; i < NUM_THREADS; i++) {
-            tasks.add(executor.submit(new MultiThreadTest.RunThreadsDescend(latch, barrier))) ;
-        }
+        executor.submitTasks(NUM_THREADS, i -> new MultiThreadTest.RunThreadsDescend(latch, barrier));
         latch.countDown();
-
-        ExecutorUtils.shutdownTaskPool(executor, tasks, timeLimitInMs);
+        executor.shutdown(TIME_LIMIT_IN_SECONDS);
 
         for (Integer i = 0; i < 2 * MAX_ITEMS_PER_CHUNK; i++) {
             Integer value = oak.get(i);

--- a/core/src/test/java/com/yahoo/oak/MultiThreadTest.java
+++ b/core/src/test/java/com/yahoo/oak/MultiThreadTest.java
@@ -30,7 +30,7 @@ public class MultiThreadTest {
     private static final int MAX_ITEMS_PER_CHUNK = 2048;
 
     private OakMap<Integer, Integer> oak;
-    private ExecutorUtils executor;
+    private ExecutorUtils<Void> executor;
 
     private CountDownLatch latch;
 
@@ -40,7 +40,7 @@ public class MultiThreadTest {
                 .setChunkMaxItems(MAX_ITEMS_PER_CHUNK);
         oak = builder.build();
         latch = new CountDownLatch(1);
-        executor = new ExecutorUtils(NUM_THREADS);
+        executor = new ExecutorUtils<>(NUM_THREADS);
     }
 
     @After

--- a/core/src/test/java/com/yahoo/oak/NativeMemoryAllocatorTest.java
+++ b/core/src/test/java/com/yahoo/oak/NativeMemoryAllocatorTest.java
@@ -30,11 +30,11 @@ public class NativeMemoryAllocatorTest {
     static final int VALUE_SIZE_AFTER_SERIALIZATION = 4 * 1024 * 1024;
     static final int KEYS_SIZE_AFTER_SERIALIZATION = Integer.BYTES;
 
-    private ExecutorUtils executor;
+    private ExecutorUtils<Slice> executor;
 
     @Before
     public void setup() {
-        executor = new ExecutorUtils(NUM_THREADS);
+        executor = new ExecutorUtils<>(NUM_THREADS);
     }
 
     @After

--- a/core/src/test/java/com/yahoo/oak/NativeMemoryAllocatorTest.java
+++ b/core/src/test/java/com/yahoo/oak/NativeMemoryAllocatorTest.java
@@ -20,8 +20,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -58,7 +56,7 @@ public class NativeMemoryAllocatorTest {
     }
 
     @Test
-    public void allocateContention() throws InterruptedException, TimeoutException, ExecutionException {
+    public void allocateContention() throws ExecutorUtils.ExecutionError {
         Random random = new Random();
         long capacity = 100;
         int blockSize = 8;

--- a/core/src/test/java/com/yahoo/oak/OffHeapOakTest.java
+++ b/core/src/test/java/com/yahoo/oak/OffHeapOakTest.java
@@ -17,8 +17,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 public class OffHeapOakTest {
     private static final int NUM_THREADS = 31;
@@ -49,7 +47,7 @@ public class OffHeapOakTest {
 
 
     @Test//(timeout = 15000)
-    public void testThreads() throws InterruptedException, TimeoutException, ExecutionException {
+    public void testThreads() throws ExecutorUtils.ExecutionError {
         executor.submitTasks(NUM_THREADS, i -> new RunThreads(latch));
         latch.countDown();
         executor.shutdown(TIME_LIMIT_IN_SECONDS);

--- a/core/src/test/java/com/yahoo/oak/OffHeapOakTest.java
+++ b/core/src/test/java/com/yahoo/oak/OffHeapOakTest.java
@@ -13,59 +13,50 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-
-
 public class OffHeapOakTest {
-    private OakMap<Integer, Integer> oak;
     private static final int NUM_THREADS = 31;
-    private ExecutorService executor;
+    private static final long TIME_LIMIT_IN_SECONDS = 250;
+
+    private static final int MAX_ITEMS_PER_CHUNK = 248;
+
+    private OakMap<Integer, Integer> oak;
+    private ExecutorUtils executor;
     private CountDownLatch latch;
-    private final int maxItemsPerChunk = 248;
     private Exception threadException;
-    private final long timeLimitInMs = TimeUnit.MILLISECONDS.convert(15000, TimeUnit.MILLISECONDS);
 
     @Before
     public void init() {
         OakMapBuilder<Integer, Integer> builder = OakCommonBuildersFactory.getDefaultIntBuilder()
-                .setChunkMaxItems(maxItemsPerChunk);
+                .setChunkMaxItems(MAX_ITEMS_PER_CHUNK);
         oak = builder.build();
         latch = new CountDownLatch(1);
-        executor = Executors.newFixedThreadPool(NUM_THREADS);
+        executor = new ExecutorUtils(NUM_THREADS);
         threadException = null;
     }
 
     @After
     public void finish() {
+        executor.shutdownNow();
         oak.close();
     }
 
 
     @Test//(timeout = 15000)
     public void testThreads() throws InterruptedException, TimeoutException, ExecutionException {
-        List<Future<?>> tasks = new ArrayList<>();
-        for (int i = 0; i < NUM_THREADS; i++) {
-            tasks.add(executor.submit(new RunThreads(latch)));
-        }
+        executor.submitTasks(NUM_THREADS, i -> new RunThreads(latch));
         latch.countDown();
-
-        ExecutorUtils.shutdownTaskPool(executor, tasks, timeLimitInMs);
+        executor.shutdown(TIME_LIMIT_IN_SECONDS);
 
         Assert.assertNull(threadException);
 
-        for (Integer i = 0; i < 6 * maxItemsPerChunk; i++) {
+        for (Integer i = 0; i < 6 * MAX_ITEMS_PER_CHUNK; i++) {
             Integer value = oak.get(i);
             Assert.assertNotNull("\n Value NULL for key " + i + "\n", value);
             if (!i.equals(value)) {
@@ -105,11 +96,11 @@ public class OffHeapOakTest {
             }
 
             // todo - perhaps check with non-zc versions
-            for (int i = 0; i < 6 * maxItemsPerChunk; i++) {
+            for (int i = 0; i < 6 * MAX_ITEMS_PER_CHUNK; i++) {
                 oak.zc().put(i, i);
             }
 
-            for (int i = 0; i < 6 * maxItemsPerChunk; i++) {
+            for (int i = 0; i < 6 * MAX_ITEMS_PER_CHUNK; i++) {
                 oak.zc().remove(i);
             }
             try {
@@ -122,7 +113,7 @@ public class OffHeapOakTest {
                             + entry.getKey(), entry.getValue());
                     Assert.assertEquals(
                             "\nAfter initial pass of put and remove (range 0-"
-                                    + (6 * maxItemsPerChunk) + "): Key " + entry.getKey()
+                                    + (6 * MAX_ITEMS_PER_CHUNK) + "): Key " + entry.getKey()
                                     + ", Value " + entry.getValue(),
                             0, entry.getValue() - entry.getKey());
                 }
@@ -130,11 +121,11 @@ public class OffHeapOakTest {
 
             }
 
-            for (int i = 0; i < 6 * maxItemsPerChunk; i++) {
+            for (int i = 0; i < 6 * MAX_ITEMS_PER_CHUNK; i++) {
                 oak.zc().putIfAbsent(i, i);
             }
 
-            for (int i = 0; i < 6 * maxItemsPerChunk; i++) {
+            for (int i = 0; i < 6 * MAX_ITEMS_PER_CHUNK; i++) {
                 oak.zc().remove(i);
             }
             try {
@@ -153,7 +144,7 @@ public class OffHeapOakTest {
             }
 
 
-            for (int i = 0; i < 6 * maxItemsPerChunk; i++) {
+            for (int i = 0; i < 6 * MAX_ITEMS_PER_CHUNK; i++) {
                 oak.zc().put(i, i);
             }
         }

--- a/core/src/test/java/com/yahoo/oak/OffHeapOakTest.java
+++ b/core/src/test/java/com/yahoo/oak/OffHeapOakTest.java
@@ -25,7 +25,7 @@ public class OffHeapOakTest {
     private static final int MAX_ITEMS_PER_CHUNK = 248;
 
     private OakMap<Integer, Integer> oak;
-    private ExecutorUtils executor;
+    private ExecutorUtils<Void> executor;
     private CountDownLatch latch;
     private Exception threadException;
 
@@ -35,7 +35,7 @@ public class OffHeapOakTest {
                 .setChunkMaxItems(MAX_ITEMS_PER_CHUNK);
         oak = builder.build();
         latch = new CountDownLatch(1);
-        executor = new ExecutorUtils(NUM_THREADS);
+        executor = new ExecutorUtils<>(NUM_THREADS);
         threadException = null;
     }
 


### PR DESCRIPTION
* Refactor `ExecutorUtils` to reduce code duplications in tests.
* ExecutorUtils.shutdown() will now throw an aggregated error of all exceptions in the pool, instead of just the firs one that fails.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
