### PR TITLE
Murmur3 hash implementation

### DIFF
--- a/core/src/main/java/com/yahoo/oak/MurmurHash3.java
+++ b/core/src/main/java/com/yahoo/oak/MurmurHash3.java
@@ -1,0 +1,449 @@
+/*
+ * Copyright 2020, Verizon Media.
+ * Licensed under the terms of the Apache 2.0 license.
+ * Please see LICENSE file in the project root for terms.
+ */
+
+package com.yahoo.oak;
+
+/**
+ * The MurmurHash3 algorithm was created by Austin Appleby and placed in the public domain.
+ * This java port was authored by Yonik Seeley and also placed into the public domain.
+ * It has been modified by Konstantin Sobolev and, you guessed it, also placed in the public domain.
+ * The author hereby disclaims copyright to this source code.
+ * <p>
+ * This produces exactly the same hash values as the final C++
+ * version of MurmurHash3 and is thus suitable for producing the same hash values across
+ * platforms.
+ * <p>
+ * The 32 bit x86 version of this hash should be the fastest variant for relatively short keys like ids.
+ * murmurhash3_x64_128 is a good choice for longer strings or if you need more than 32 bits of hash.
+ * <p>
+ * Note - The x86 and x64 versions do _not_ produce the same results, as the
+ * algorithms are optimized for their respective platforms.
+ */
+public final class MurmurHash3 {
+    static final long MURMUR_128_C1 = 0x87c37b91114253d5L;
+    static final long MURMUR_128_C2 = 0x4cf5ad432745937fL;
+
+    static final int MURMUR_32_C1 = 0xcc9e2d51;
+    static final int MURMUR_32_C2 = 0x1b873593;
+
+    /**
+     * 128 bits of state
+     */
+    public static final class HashCode128 {
+        private static final char[] HEX_DIGITS = "0123456789abcdef".toCharArray();
+
+        /**
+         * First part of the hash, use it if you only need 64-bit hash
+         */
+        private long val1;
+        /**
+         * Second part of the hash
+         */
+        private long val2;
+
+        public HashCode128(long v1, long v2) {
+            val1 = v1;
+            val2 = v2;
+        }
+
+        public HashCode128() {
+            this(0, 0);
+        }
+
+        public byte[] getBytes() {
+            return new byte[]{
+                    (byte) val1,
+                    (byte) (val1 >>> 8),
+                    (byte) (val1 >>> 16),
+                    (byte) (val1 >>> 24),
+                    (byte) (val1 >>> 32),
+                    (byte) (val1 >>> 40),
+                    (byte) (val1 >>> 48),
+                    (byte) (val1 >>> 56),
+                    (byte) val2,
+                    (byte) (val2 >>> 8),
+                    (byte) (val2 >>> 16),
+                    (byte) (val2 >>> 24),
+                    (byte) (val2 >>> 32),
+                    (byte) (val2 >>> 40),
+                    (byte) (val2 >>> 48),
+                    (byte) (val2 >>> 56),
+            };
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final HashCode128 pair = (HashCode128) o;
+            return val1 == pair.val1 && val2 == pair.val2;
+        }
+
+        @Override
+        public int hashCode() {
+            return (int) (val1 * 31 + val2);
+        }
+
+        public int toInt() {
+            return (int) val1;
+        }
+
+        public long toLong() {
+            return val1;
+        }
+
+        @Override
+        public String toString() {
+            byte[] bytes = getBytes();
+            StringBuilder sb = new StringBuilder(2 * bytes.length);
+            for (byte b : bytes) {
+                sb.append(HEX_DIGITS[(b >>> 4) & 0xf]).append(HEX_DIGITS[b & 0xf]);
+            }
+            return sb.toString();
+        }
+
+        public static MurmurHash3.HashCode128 fromBytes(byte[] bytes) {
+            return new HashCode128(
+                    getLongLittleEndian(bytes, 0),
+                    getLongLittleEndian(bytes, 8)
+            );
+        }
+    }
+
+    public static long fmix64(final long inputK) {
+        long k = inputK;
+        k ^= k >>> 33;
+        k *= 0xff51afd7ed558ccdL;
+        k ^= k >>> 33;
+        k *= 0xc4ceb9fe1a85ec53L;
+        k ^= k >>> 33;
+        return k;
+    }
+
+    /**
+     * Gets a long from a byte buffer in little endian byte order.
+     */
+    public static long getLongLittleEndian(byte[] buf, int offset) {
+        return ((long) buf[offset + 7] << 56)   // no mask needed
+                | ((buf[offset + 6] & 0xffL) << 48)
+                | ((buf[offset + 5] & 0xffL) << 40)
+                | ((buf[offset + 4] & 0xffL) << 32)
+                | ((buf[offset + 3] & 0xffL) << 24)
+                | ((buf[offset + 2] & 0xffL) << 16)
+                | ((buf[offset + 1] & 0xffL) << 8)
+                | ((buf[offset] & 0xffL));        // no shift needed
+    }
+
+    /**
+     * Gets a long from a byte buffer in little endian byte order, modified for OakBuffer
+     */
+    public static long getLongLittleEndian(OakBuffer buf, int offset) {
+        return ((long) buf.get(offset + 7) << 56)   // no mask needed
+                | ((buf.get(offset + 6) & 0xffL) << 48)
+                | ((buf.get(offset + 5) & 0xffL) << 40)
+                | ((buf.get(offset + 4) & 0xffL) << 32)
+                | ((buf.get(offset + 3) & 0xffL) << 24)
+                | ((buf.get(offset + 2) & 0xffL) << 16)
+                | ((buf.get(offset + 1) & 0xffL) << 8)
+                | ((buf.get(offset) & 0xffL));        // no shift needed
+    }
+
+
+    /**
+     * Returns the MurmurHash3_x86_32 hash.
+     */
+    public static int murmurhash32(byte[] data, int offset, int len, int seed) {
+        int h1 = seed;
+        int roundedEnd = offset + (len & 0xfffffffc);  // round down to 4 byte block
+
+        for (int i = offset; i < roundedEnd; i += 4) {
+            // little endian load order
+            int k1 = (data[i] & 0xff) |
+                    ((data[i + 1] & 0xff) << 8) |
+                    ((data[i + 2] & 0xff) << 16) |
+                    (data[i + 3] << 24);
+            k1 *= MURMUR_32_C1;
+            k1 = (k1 << 15) | (k1 >>> 17);  // ROTL32(k1,15);
+            k1 *= MURMUR_32_C2;
+
+            h1 ^= k1;
+            h1 = (h1 << 13) | (h1 >>> 19);  // ROTL32(h1,13);
+            h1 = h1 * 5 + 0xe6546b64;
+        }
+
+        // tail
+        int k1 = 0;
+
+        switch (len & 0x03) {
+            case 3:
+                k1 = (data[roundedEnd + 2] & 0xff) << 16;
+                // fallthrough
+            case 2:
+                k1 |= (data[roundedEnd + 1] & 0xff) << 8;
+                // fallthrough
+            case 1:
+                k1 |= (data[roundedEnd] & 0xff);
+                k1 *= MURMUR_32_C1;
+                k1 = (k1 << 15) | (k1 >>> 17);  // ROTL32(k1,15);
+                k1 *= MURMUR_32_C2;
+                h1 ^= k1;
+        }
+
+        // finalization
+        h1 ^= len;
+
+        // fmix(h1);
+        h1 ^= h1 >>> 16;
+        h1 *= 0x85ebca6b;
+        h1 ^= h1 >>> 13;
+        h1 *= 0xc2b2ae35;
+        h1 ^= h1 >>> 16;
+
+        return h1;
+    }
+
+    /**
+     * Returns the MurmurHash3_x86_32 hash, modified for OakBuffer.
+     */
+    public static int murmurhash32(OakBuffer data, int offset, int len, int seed) {
+        int h1 = seed;
+        int roundedEnd = offset + (len & 0xfffffffc);  // round down to 4 byte block
+
+        for (int i = offset; i < roundedEnd; i += 4) {
+            // little endian load order
+            int k1 = (data.get(i) & 0xff) |
+                    ((data.get(i + 1) & 0xff) << 8) |
+                    ((data.get(i + 2) & 0xff) << 16) |
+                    (data.get(i + 3) << 24);
+            k1 *= MURMUR_32_C1;
+            k1 = (k1 << 15) | (k1 >>> 17);  // ROTL32(k1,15);
+            k1 *= MURMUR_32_C2;
+
+            h1 ^= k1;
+            h1 = (h1 << 13) | (h1 >>> 19);  // ROTL32(h1,13);
+            h1 = h1 * 5 + 0xe6546b64;
+        }
+
+        // tail
+        int k1 = 0;
+
+        switch (len & 0x03) {
+            case 3:
+                k1 = (data.get(roundedEnd + 2) & 0xff) << 16;
+                // fallthrough
+            case 2:
+                k1 |= (data.get(roundedEnd + 1) & 0xff) << 8;
+                // fallthrough
+            case 1:
+                k1 |= (data.get(roundedEnd) & 0xff);
+                k1 *= MURMUR_32_C1;
+                k1 = (k1 << 15) | (k1 >>> 17);  // ROTL32(k1,15);
+                k1 *= MURMUR_32_C2;
+                h1 ^= k1;
+        }
+
+        // finalization
+        h1 ^= len;
+
+        // fmix(h1);
+        h1 ^= h1 >>> 16;
+        h1 *= 0x85ebca6b;
+        h1 ^= h1 >>> 13;
+        h1 *= 0xc2b2ae35;
+        h1 ^= h1 >>> 16;
+
+        return h1;
+    }
+
+    /**
+     * Returns the MurmurHash3_x64_128 hash, placing the result in "out".
+     */
+    public static void murmurhash128(byte[] key, int offset, int len, int seed, HashCode128 out) {
+        // The original algorithm does have a 32 bit unsigned seed.
+        // We have to mask to match the behavior of the unsigned types and prevent sign extension.
+        long h1 = seed & 0x00000000FFFFFFFFL;
+        long h2 = seed & 0x00000000FFFFFFFFL;
+
+        int roundedEnd = offset + (len & 0xFFFFFFF0);  // round down to 16 byte block
+        for (int i = offset; i < roundedEnd; i += 16) {
+            long k1 = getLongLittleEndian(key, i);
+            long k2 = getLongLittleEndian(key, i + 8);
+            k1 *= MURMUR_128_C1;
+            k1 = Long.rotateLeft(k1, 31);
+            k1 *= MURMUR_128_C2;
+            h1 ^= k1;
+            h1 = Long.rotateLeft(h1, 27);
+            h1 += h2;
+            h1 = h1 * 5 + 0x52dce729;
+            k2 *= MURMUR_128_C2;
+            k2 = Long.rotateLeft(k2, 33);
+            k2 *= MURMUR_128_C1;
+            h2 ^= k2;
+            h2 = Long.rotateLeft(h2, 31);
+            h2 += h1;
+            h2 = h2 * 5 + 0x38495ab5;
+        }
+
+        long k1 = 0;
+        long k2 = 0;
+
+        switch (len & 15) {
+            case 15:
+                k2 = (key[roundedEnd + 14] & 0xffL) << 48;
+            case 14:
+                k2 |= (key[roundedEnd + 13] & 0xffL) << 40;
+            case 13:
+                k2 |= (key[roundedEnd + 12] & 0xffL) << 32;
+            case 12:
+                k2 |= (key[roundedEnd + 11] & 0xffL) << 24;
+            case 11:
+                k2 |= (key[roundedEnd + 10] & 0xffL) << 16;
+            case 10:
+                k2 |= (key[roundedEnd + 9] & 0xffL) << 8;
+            case 9:
+                k2 |= (key[roundedEnd + 8] & 0xffL);
+                k2 *= MURMUR_128_C2;
+                k2 = Long.rotateLeft(k2, 33);
+                k2 *= MURMUR_128_C1;
+                h2 ^= k2;
+            case 8:
+                k1 = ((long) key[roundedEnd + 7]) << 56;
+            case 7:
+                k1 |= (key[roundedEnd + 6] & 0xffL) << 48;
+            case 6:
+                k1 |= (key[roundedEnd + 5] & 0xffL) << 40;
+            case 5:
+                k1 |= (key[roundedEnd + 4] & 0xffL) << 32;
+            case 4:
+                k1 |= (key[roundedEnd + 3] & 0xffL) << 24;
+            case 3:
+                k1 |= (key[roundedEnd + 2] & 0xffL) << 16;
+            case 2:
+                k1 |= (key[roundedEnd + 1] & 0xffL) << 8;
+            case 1:
+                k1 |= (key[roundedEnd] & 0xffL);
+                k1 *= MURMUR_128_C1;
+                k1 = Long.rotateLeft(k1, 31);
+                k1 *= MURMUR_128_C2;
+                h1 ^= k1;
+        }
+
+        //----------
+        // finalization
+
+        h1 ^= len;
+        h2 ^= len;
+
+        h1 += h2;
+        h2 += h1;
+
+        h1 = fmix64(h1);
+        h2 = fmix64(h2);
+
+        h1 += h2;
+        h2 += h1;
+
+        out.val1 = h1;
+        out.val2 = h2;
+    }
+
+    /**
+     * Returns the MurmurHash3_x64_128 hash, placing the result in "out".
+     */
+    public static void murmurhash128(OakBuffer key, int offset, int len, int seed, HashCode128 out) {
+        // The original algorithm does have a 32 bit unsigned seed.
+        // We have to mask to match the behavior of the unsigned types and prevent sign extension.
+        long h1 = seed & 0x00000000FFFFFFFFL;
+        long h2 = seed & 0x00000000FFFFFFFFL;
+
+        int roundedEnd = offset + (len & 0xFFFFFFF0);  // round down to 16 byte block
+        for (int i = offset; i < roundedEnd; i += 16) {
+            long k1 = getLongLittleEndian(key, i);
+            long k2 = getLongLittleEndian(key, i + 8);
+            k1 *= MURMUR_128_C1;
+            k1 = Long.rotateLeft(k1, 31);
+            k1 *= MURMUR_128_C2;
+            h1 ^= k1;
+            h1 = Long.rotateLeft(h1, 27);
+            h1 += h2;
+            h1 = h1 * 5 + 0x52dce729;
+            k2 *= MURMUR_128_C2;
+            k2 = Long.rotateLeft(k2, 33);
+            k2 *= MURMUR_128_C1;
+            h2 ^= k2;
+            h2 = Long.rotateLeft(h2, 31);
+            h2 += h1;
+            h2 = h2 * 5 + 0x38495ab5;
+        }
+
+        long k1 = 0;
+        long k2 = 0;
+
+        switch (len & 15) {
+            case 15:
+                k2 = (key.get(roundedEnd + 14) & 0xffL) << 48;
+            case 14:
+                k2 |= (key.get(roundedEnd + 13) & 0xffL) << 40;
+            case 13:
+                k2 |= (key.get(roundedEnd + 12) & 0xffL) << 32;
+            case 12:
+                k2 |= (key.get(roundedEnd + 11) & 0xffL) << 24;
+            case 11:
+                k2 |= (key.get(roundedEnd + 10) & 0xffL) << 16;
+            case 10:
+                k2 |= (key.get(roundedEnd + 9) & 0xffL) << 8;
+            case 9:
+                k2 |= (key.get(roundedEnd + 8) & 0xffL);
+                k2 *= MURMUR_128_C2;
+                k2 = Long.rotateLeft(k2, 33);
+                k2 *= MURMUR_128_C1;
+                h2 ^= k2;
+            case 8:
+                k1 = ((long) key.get(roundedEnd + 7)) << 56;
+            case 7:
+                k1 |= (key.get(roundedEnd + 6) & 0xffL) << 48;
+            case 6:
+                k1 |= (key.get(roundedEnd + 5) & 0xffL) << 40;
+            case 5:
+                k1 |= (key.get(roundedEnd + 4) & 0xffL) << 32;
+            case 4:
+                k1 |= (key.get(roundedEnd + 3) & 0xffL) << 24;
+            case 3:
+                k1 |= (key.get(roundedEnd + 2) & 0xffL) << 16;
+            case 2:
+                k1 |= (key.get(roundedEnd + 1) & 0xffL) << 8;
+            case 1:
+                k1 |= (key.get(roundedEnd) & 0xffL);
+                k1 *= MURMUR_128_C1;
+                k1 = Long.rotateLeft(k1, 31);
+                k1 *= MURMUR_128_C2;
+                h1 ^= k1;
+        }
+
+        //----------
+        // finalization
+
+        h1 ^= len;
+        h2 ^= len;
+
+        h1 += h2;
+        h2 += h1;
+
+        h1 = fmix64(h1);
+        h2 = fmix64(h2);
+
+        h1 += h2;
+        h2 += h1;
+
+        out.val1 = h1;
+        out.val2 = h2;
+    }
+}

--- a/core/src/main/java/com/yahoo/oak/common/OakCommonBuildersFactory.java
+++ b/core/src/main/java/com/yahoo/oak/common/OakCommonBuildersFactory.java
@@ -9,6 +9,8 @@ package com.yahoo.oak.common;
 import com.yahoo.oak.OakComparator;
 import com.yahoo.oak.OakMapBuilder;
 import com.yahoo.oak.OakSerializer;
+import com.yahoo.oak.common.bytearray.OakByteArrayComparator;
+import com.yahoo.oak.common.bytearray.OakByteArraySerializer;
 import com.yahoo.oak.common.intbuffer.OakIntBufferComparator;
 import com.yahoo.oak.common.intbuffer.OakIntBufferSerializer;
 import com.yahoo.oak.common.integer.OakIntComparator;
@@ -43,6 +45,19 @@ public class OakCommonBuildersFactory {
     public static OakMapBuilder<String, String> getDefaultStringBuilder() {
         return new OakMapBuilder<>(
                 DEFAULT_STRING_COMPARATOR, DEFAULT_STRING_SERIALIZER, DEFAULT_STRING_SERIALIZER, "");
+    }
+
+    // #####################################################################################
+    // Byte array factories
+    // #####################################################################################
+
+    public static final OakComparator<byte[]> DEFAULT_BYTE_ARRAY_COMPARATOR = new OakByteArrayComparator();
+    public static final OakSerializer<byte[]> DEFAULT_BYTE_ARRAY_SERIALIZER = new OakByteArraySerializer();
+
+    public static OakMapBuilder<byte[], byte[]> getDefaultByteArrayBuilder() {
+        return new OakMapBuilder<>(
+                DEFAULT_BYTE_ARRAY_COMPARATOR, DEFAULT_BYTE_ARRAY_SERIALIZER, DEFAULT_BYTE_ARRAY_SERIALIZER,
+                new byte[] {});
     }
 
 

--- a/core/src/main/java/com/yahoo/oak/common/bytearray/OakByteArrayComparator.java
+++ b/core/src/main/java/com/yahoo/oak/common/bytearray/OakByteArrayComparator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020, Verizon Media.
+ * Licensed under the terms of the Apache 2.0 license.
+ * Please see LICENSE file in the project root for terms.
+ */
+
+package com.yahoo.oak.common.bytearray;
+
+import com.yahoo.oak.OakComparator;
+import com.yahoo.oak.OakScopedReadBuffer;
+
+public class OakByteArrayComparator implements OakComparator<byte[]> {
+
+    @Override
+    public int compareKeys(byte[] key1, byte[] key2) {
+        return compare(
+                key1, 0, key1.length,
+                key2, 0, key2.length
+        );
+    }
+
+    @Override
+    public int compareSerializedKeys(OakScopedReadBuffer serializedKey1, OakScopedReadBuffer serializedKey2) {
+        return compare(
+                serializedKey1, 0, OakByteArraySerializer.getSerializedSize(serializedKey1),
+                serializedKey2, 0, OakByteArraySerializer.getSerializedSize(serializedKey2)
+        );
+    }
+
+    @Override
+    public int compareKeyAndSerializedKey(byte[] key, OakScopedReadBuffer serializedKey) {
+        return compare(
+                key, 0, key.length,
+                serializedKey, 0, OakByteArraySerializer.getSerializedSize(serializedKey)
+        );
+    }
+
+    public static int compare(OakScopedReadBuffer buff1, int pos1, int size1,
+                              OakScopedReadBuffer buff2, int pos2, int size2) {
+
+        int minSize = Math.min(size1, size2);
+
+        for (int i = 0; i < minSize; i++) {
+            final int compare = Byte.compare(
+                    OakByteArraySerializer.getSerializedByte(buff1, pos1 + i),
+                    OakByteArraySerializer.getSerializedByte(buff2, pos2 + i)
+            );
+            if (compare != 0) {
+                return compare;
+            }
+        }
+
+        return Integer.compare(size1, size2);
+    }
+
+    public static int compare(byte[] key1, int pos1, int size1, OakScopedReadBuffer buff2, int pos2, int size2) {
+        final int minSize = Math.min(size1, size2);
+
+        for (int i = 0; i < minSize; i++) {
+            final int compare = Byte.compare(
+                    key1[pos1 + i],
+                    OakByteArraySerializer.getSerializedByte(buff2, pos2 + i)
+            );
+            if (compare != 0) {
+                return compare;
+            }
+        }
+
+        return Integer.compare(size1, size2);
+    }
+
+    public static int compare(byte[] key1, int pos1, int size1, byte[] key2, int pos2, int size2) {
+        final int minSize = Math.min(size1, size2);
+
+        for (int i = 0; i < minSize; i++) {
+            final int compare = Byte.compare(
+                    key1[pos1 + i],
+                    key2[pos2 + i]
+            );
+            if (compare != 0) {
+                return compare;
+            }
+        }
+
+        return Integer.compare(size1, size2);
+    }
+}

--- a/core/src/main/java/com/yahoo/oak/common/bytearray/OakByteArraySerializer.java
+++ b/core/src/main/java/com/yahoo/oak/common/bytearray/OakByteArraySerializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020, Verizon Media.
+ * Licensed under the terms of the Apache 2.0 license.
+ * Please see LICENSE file in the project root for terms.
+ */
+
+package com.yahoo.oak.common.bytearray;
+
+import com.yahoo.oak.OakBuffer;
+import com.yahoo.oak.OakScopedReadBuffer;
+import com.yahoo.oak.OakScopedWriteBuffer;
+import com.yahoo.oak.OakSerializer;
+
+public class OakByteArraySerializer implements OakSerializer<byte[]> {
+
+    static final int SIZE_OFFSET = Integer.BYTES;
+
+    @Override
+    public void serialize(byte[] object, OakScopedWriteBuffer targetBuffer) {
+        final int size = object.length;
+        putSerializedSize(targetBuffer, size);
+
+        for (int i = 0; i < size; i++) {
+            putSerializedByte(targetBuffer, i, object[i]);
+        }
+    }
+
+    @Override
+    public byte[] deserialize(OakScopedReadBuffer oakBuffer) {
+        final int size = getSerializedSize(oakBuffer);
+
+        final byte[] object = new byte[size];
+        for (int i = 0; i < size; i++) {
+            object[i] = getSerializedByte(oakBuffer, i);
+        }
+        return object;
+    }
+
+    @Override
+    public int calculateSize(byte[] object) {
+        return SIZE_OFFSET + object.length;
+    }
+
+    public static int getSerializedSize(OakBuffer oakBuffer) {
+        return oakBuffer.getInt(0);
+    }
+
+    public static void putSerializedSize(OakScopedWriteBuffer oakBuffer, int size) {
+        oakBuffer.putInt(0, size);
+    }
+
+    public static byte getSerializedByte(OakBuffer oakBuffer, int index) {
+        return oakBuffer.get(index + SIZE_OFFSET);
+    }
+
+    public static void putSerializedByte(OakScopedWriteBuffer oakBuffer, int index, byte b) {
+        oakBuffer.put(index + SIZE_OFFSET, b);
+    }
+}

--- a/core/src/test/java/com/yahoo/oak/BuildAllTypesTest.java
+++ b/core/src/test/java/com/yahoo/oak/BuildAllTypesTest.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.oak;
 
+import com.yahoo.oak.common.OakCommonBuildersFactory;
 import com.yahoo.oak.common.floatnum.OakFloatComparator;
 import com.yahoo.oak.common.floatnum.OakFloatSerializer;
 import com.yahoo.oak.common.integer.OakIntComparator;
@@ -24,7 +25,7 @@ public class BuildAllTypesTest {
         OakIntSerializer intSerializer2 = new OakIntSerializer();
         OakIntComparator intComparator = new OakIntComparator();
 
-        OakMapBuilder<Integer, Integer> builder = new OakMapBuilder<Integer, Integer>(intComparator, intSerializer,
+        OakMapBuilder<Integer, Integer> builder = new OakMapBuilder<>(intComparator, intSerializer,
                 intSerializer2, Integer.MIN_VALUE).setMemoryCapacity(MEBIBYTE); // 1MB in bytes
 
         OakMap<Integer, Integer> oak = builder.buildOrderedMap();
@@ -33,7 +34,7 @@ public class BuildAllTypesTest {
         int myVal = 1;
         oak.put(myKey, myVal);
 
-        Assert.assertTrue(oak.get(myKey) == myVal);
+        Assert.assertEquals((int) oak.get(myKey), myVal);
 
     }
 
@@ -43,7 +44,7 @@ public class BuildAllTypesTest {
         OakFloatSerializer floatSerializer = new OakFloatSerializer();
         OakIntComparator intComparator = new OakIntComparator();
 
-        OakMapBuilder<Integer, Float> builder = new OakMapBuilder<Integer, Float>(intComparator, intSerializer,
+        OakMapBuilder<Integer, Float> builder = new OakMapBuilder<>(intComparator, intSerializer,
                 floatSerializer, Integer.MIN_VALUE).setMemoryCapacity(MEBIBYTE); // 1MB in bytes
 
         OakMap<Integer, Float> oak = builder.buildOrderedMap();
@@ -52,7 +53,7 @@ public class BuildAllTypesTest {
         float myVal = (float) 3.14;
         oak.put(myKey, myVal);
 
-        Assert.assertTrue(oak.get(myKey) == myVal);
+        Assert.assertEquals(oak.get(myKey), myVal, 0.0);
 
     }
 
@@ -62,7 +63,7 @@ public class BuildAllTypesTest {
         OakStringSerializer stringSerializer = new OakStringSerializer();
         OakFloatComparator floatComparator = new OakFloatComparator();
 
-        OakMapBuilder<Float, String> builder = new OakMapBuilder<Float, String>(floatComparator, floatSerializer,
+        OakMapBuilder<Float, String> builder = new OakMapBuilder<>(floatComparator, floatSerializer,
                 stringSerializer, Float.MIN_VALUE).setMemoryCapacity(MEBIBYTE); // 1MB in bytes
 
         OakMap<Float, String> oak = builder.buildOrderedMap();
@@ -71,8 +72,18 @@ public class BuildAllTypesTest {
         String myVal = "val";
         oak.put(myKey, myVal);
 
-        Assert.assertTrue(oak.get(myKey).equals(myVal));
+        Assert.assertEquals(oak.get(myKey), myVal);
 
+    }
+
+    @Test
+    public void testBuildByteArray() {
+        OakMap<byte[], byte[]> oak = OakCommonBuildersFactory.getDefaultByteArrayBuilder().buildOrderedMap();
+
+        final byte[] key = new byte[] {1, 2, 3};
+        oak.put(key, key);
+
+        Assert.assertArrayEquals(key, oak.get(key));
     }
 
     // TODO add all type combinations

--- a/core/src/test/java/com/yahoo/oak/Murmur.java
+++ b/core/src/test/java/com/yahoo/oak/Murmur.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020, Verizon Media.
+ * Licensed under the terms of the Apache 2.0 license.
+ * Please see LICENSE file in the project root for terms.
+ */
+
+package com.yahoo.oak;
+
+import com.yahoo.oak.common.OakCommonBuildersFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class Murmur {
+
+    private OakMap<byte[], byte[]> oak;
+
+    @Before
+    public void init() {
+        oak = OakCommonBuildersFactory.getDefaultByteArrayBuilder().buildOrderedMap();
+    }
+
+    @After
+    public void finish() {
+        oak.close();
+    }
+
+    @Test
+    public void test32() {
+        final byte[] test = new byte[] {1, 2, 3};
+        final int expected = MurmurHash3.murmurhash32(test, 0, test.length, 0);
+        oak.put(test, test);
+
+        OakBuffer oakBuffer = oak.zc().get(test);
+        Assert.assertNotNull(oakBuffer);
+
+        Assert.assertEquals(test.length, oakBuffer.capacity() - Integer.BYTES);
+
+        final int actual = MurmurHash3.murmurhash32(oakBuffer, Integer.BYTES, test.length, 0);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void test128() {
+        final byte[] test = new byte[] {1, 2, 3};
+        final MurmurHash3.HashCode128 expected = new MurmurHash3.HashCode128();
+        MurmurHash3.murmurhash128(test, 0, test.length, 0, expected);
+        oak.put(test, test);
+
+        OakBuffer oakBuffer = oak.zc().get(test);
+        Assert.assertNotNull(oakBuffer);
+
+        Assert.assertEquals(test.length, oakBuffer.capacity() - Integer.BYTES);
+
+        final MurmurHash3.HashCode128 actual = new MurmurHash3.HashCode128();
+        MurmurHash3.murmurhash128(oakBuffer, Integer.BYTES, test.length, 0, actual);
+        Assert.assertEquals(expected, actual);
+    }
+}

--- a/core/src/test/java/com/yahoo/oak/MurmurTest.java
+++ b/core/src/test/java/com/yahoo/oak/MurmurTest.java
@@ -12,7 +12,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class Murmur {
+public class MurmurTest {
 
     private OakMap<byte[], byte[]> oak;
 


### PR DESCRIPTION
* Add MurMur3 hash implementation (taken from [eprst](https://github.com/eprst/murmur3)) with added support for OakBuffer
* Add ByteArray map builder
* Add tests

This is a very good explanation of the flaw of murmur2: https://sites.google.com/site/murmurhash/murmurhash2flaw

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
