### PR TITLE
supporting JDK17

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -84,4 +84,29 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+    	<profile>
+    		<activation>
+    			<jdk>[9,)</jdk>
+   			</activation>
+            <build>
+            <plugins>
+            	<plugin>
+            		<artifactId>maven-surefire-plugin</artifactId>
+           			<configuration>
+                    	<argLine>
+                        	-Xmx20g
+                            @{jacocoArgLine}
+                            -XX:MaxDirectMemorySize=4g
+                            --add-modules jdk.incubator.foreign
+                            --add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED
+                            --add-opens java.base/java.nio=ALL-UNNAMED
+                            --enable-native-access=ALL-UNNAMED
+                         </argLine>
+                         </configuration>
+                     </plugin>
+                     </plugins>
+                     </build>
+                     </profile>
+		</profiles>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -90,23 +90,23 @@
     			<jdk>[9,)</jdk>
    			</activation>
             <build>
-            <plugins>
-            	<plugin>
-            		<artifactId>maven-surefire-plugin</artifactId>
-           			<configuration>
-                    	<argLine>
-                        	-Xmx20g
-                            @{jacocoArgLine}
-                            -XX:MaxDirectMemorySize=4g
-                            --add-modules jdk.incubator.foreign
-                            --add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED
-                            --add-opens java.base/java.nio=ALL-UNNAMED
-                            --enable-native-access=ALL-UNNAMED
-                         </argLine>
-                         </configuration>
+            	<plugins>
+            		<plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>
+                        		-Xmx20g
+                        		@{jacocoArgLine}
+                        		-XX:MaxDirectMemorySize=4g
+                        		--add-modules jdk.incubator.foreign
+                        		--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED
+                        		--add-opens java.base/java.nio=ALL-UNNAMED
+                        		--enable-native-access=ALL-UNNAMED
+                        	 </argLine>
+                        </configuration>
                      </plugin>
-                     </plugins>
-                     </build>
-                     </profile>
-		</profiles>
+            	</plugins>
+            </build>
+    	</profile>
+   	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,14 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+        	<activation>
+			<jdk>[9,)</jdk>
+            </activation>
+            <properties>
+            	<maven.compiler.release>17</maven.compiler.release>
+           	</properties>
+	    </profile>
     </profiles>
 
     <dependencies>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Hey,
I am opening this PR to allow Oak to work with JDK>=8, with minimal effort and without having to change a lot of code.
While still using Unsafe and other sealed packages, though it is not encouraged anymore, and there exists some new alternatives that could replace them.

my changes introduce a new profile to the poms that we in order compile with JDK>= 8 and to run with JDK>=11
two tests fail when ran with JDK17, due to the changes introduced to the JDK past JDK8, which I need your help with (I still think there would be minimal effort to fix them)
 