### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
     - run: git fetch origin master
     - name: Get latest release commit ID
       id: latest_release
-      run: echo "::set-output name=commit_id::$(git log --pretty=format:"%h%x09%s" -n 1000 | grep "prepare release" | head -1 | cut -f1)"
+      run: echo "commit_id=$(git log --pretty=format:"%h%x09%s" -n 1000 | grep "prepare release" | head -1 | cut -f1)" >> $GITHUB_OUTPUT
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter